### PR TITLE
Add Lovelace card for drink counter

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,21 @@ All drinks are stored in a single price list. A dedicated user named
 exposes one price sensor per drink while regular users only get count and total
 amount sensors. You can edit the drinks and their prices at any time from the
 integration options.
+
+## Lovelace Card
+
+A simple Lovelace card is provided in `www/drink-counter-card.js`.
+It automatically lists all configured users, their drink counters and
+current costs. Each drink has a `+` button to add a drink and a `Reset`
+button to clear all counters for a user.
+
+Add the file as a resource in Home Assistant:
+
+```yaml
+lovelace:
+  resources:
+    - url: /local/drink-counter-card.js
+      type: module
+```
+
+Then add a new card with type `custom:drink-counter-card`.

--- a/www/drink-counter-card.js
+++ b/www/drink-counter-card.js
@@ -1,0 +1,105 @@
+class DrinkCounterCard extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+    this.shadowRoot.innerHTML = `
+      <style>
+        :host {
+          display: block;
+          padding: 16px;
+        }
+        h3 {
+          margin: 8px 0;
+        }
+        ul {
+          list-style: none;
+          padding: 0;
+        }
+        li {
+          display: flex;
+          align-items: center;
+          margin: 4px 0;
+        }
+        button {
+          margin-left: 8px;
+        }
+      </style>
+      <div id="content"></div>
+    `;
+    this._content = this.shadowRoot.getElementById('content');
+    this.shadowRoot.addEventListener('click', (ev) => {
+      const target = ev.target;
+      if (target.dataset.drink) {
+        this._hass.callService('drink_counter', 'add_drink', {
+          user: target.dataset.user,
+          drink: target.dataset.drink,
+        });
+      } else if (target.dataset.reset) {
+        this._hass.callService('drink_counter', 'reset_counters', {
+          user: target.dataset.reset,
+        });
+      }
+    });
+  }
+
+  setConfig(config) {
+    this._config = Object.assign({ title: 'Drink Counter' }, config);
+  }
+
+  set hass(hass) {
+    this._hass = hass;
+    if (!this._content) return;
+    const prices = {};
+    Object.values(hass.states).forEach((st) => {
+      const name = st.attributes.friendly_name;
+      if (
+        st.entity_id.startsWith('sensor.') &&
+        name &&
+        name.startsWith('Preisliste') &&
+        name.endsWith('Price')
+      ) {
+        const drink = name.substring('Preisliste '.length, name.length - 6);
+        prices[drink] = parseFloat(st.state);
+      }
+    });
+    const users = {};
+    Object.values(hass.states).forEach((st) => {
+      const name = st.attributes.friendly_name;
+      if (!name || !st.entity_id.startsWith('sensor.')) return;
+      if (name.endsWith('Count')) {
+        const parts = name.split(' ');
+        const user = parts.shift();
+        if (user === 'Preisliste') return;
+        const drink = parts.slice(0, -1).join(' ');
+        users[user] = users[user] || { drinks: {} };
+        users[user].drinks[drink] = parseInt(st.state, 10);
+      } else if (name.endsWith('Amount Due')) {
+        const user = name.substring(0, name.length - ' Amount Due'.length);
+        if (user === 'Preisliste') return;
+        users[user] = users[user] || { drinks: {} };
+        users[user].amount = st.state;
+      }
+    });
+    let html = `<h2>${this._config.title}</h2>`;
+    Object.keys(users).forEach((user) => {
+      const data = users[user];
+      html += `<h3>${user} - ${data.amount || '0'} €</h3>`;
+      html += '<ul>';
+      Object.keys(prices).forEach((drink) => {
+        const count = data.drinks[drink] || 0;
+        const total = (count * (prices[drink] || 0)).toFixed(2);
+        html += `<li>${drink}: ${count} (${total} €)`;
+        html += ` <button data-user="${user}" data-drink="${drink}">+</button></li>`;
+      });
+      html += '</ul>';
+      html += `<button data-reset="${user}">Reset</button>`;
+    });
+    this._content.innerHTML = html;
+  }
+
+  getCardSize() {
+    return 3;
+  }
+}
+
+customElements.define('drink-counter-card', DrinkCounterCard);


### PR DESCRIPTION
## Summary
- add `drink-counter-card.js` custom Lovelace card
- document the card in README

## Testing
- `python -m py_compile custom_components/drink_counter/*.py`

------
https://chatgpt.com/codex/tasks/task_e_687ced4c0ab8832e92339ce1c519ce1e