### PR TITLE
Implement user exclusion from Tally List

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The integration allows you to manage drink tallies for multiple persons from Hom
 - Service `tally_list.remove_drink` to remove a drink for a person.
 - Service `tally_list.adjust_count` to set a drink count to a specific value.
 - Counters cannot go below zero when removing drinks.
+- Exclude persons from automatic import via the integration options.
 
 ## Installation
 

--- a/custom_components/tally_list/const.py
+++ b/custom_components/tally_list/const.py
@@ -5,6 +5,7 @@ CONF_DRINKS = "drinks"
 CONF_DRINK = "drink"
 CONF_PRICE = "price"
 CONF_FREE_AMOUNT = "free_amount"
+CONF_EXCLUDED_USERS = "excluded_users"
 
 ATTR_USER = "user"
 ATTR_DRINK = "drink"

--- a/custom_components/tally_list/translations/de.json
+++ b/custom_components/tally_list/translations/de.json
@@ -58,6 +58,20 @@
           "data": {
             "free_amount": "Freibetrag"
           }
+        },
+        "add_excluded_user": {
+          "title": "Nutzer ausschließen",
+          "data": {
+            "user": "Nutzer",
+            "add_more": "Weiteren ausschließen"
+          }
+        },
+        "remove_excluded_user": {
+          "title": "Ausschluss aufheben",
+          "data": {
+            "user": "Nutzer",
+            "remove_more": "Weiteren einschließen"
+          }
         }
       },
       "enum": {
@@ -66,6 +80,8 @@
           "remove": "Entfernen",
           "edit": "Bearbeiten",
           "free_amount": "Freibetrag",
+          "exclude": "Ausschließen",
+          "include": "Einschließen",
           "finish": "Fertig"
         }
       }

--- a/custom_components/tally_list/translations/en.json
+++ b/custom_components/tally_list/translations/en.json
@@ -58,6 +58,20 @@
           "data": {
             "free_amount": "Free amount"
           }
+        },
+        "add_excluded_user": {
+          "title": "Exclude User",
+          "data": {
+            "user": "User",
+            "add_more": "Exclude another"
+          }
+        },
+        "remove_excluded_user": {
+          "title": "Include User",
+          "data": {
+            "user": "User",
+            "remove_more": "Include another"
+          }
         }
       },
       "enum": {
@@ -66,6 +80,8 @@
           "remove": "Remove drink",
           "edit": "Edit price",
           "free_amount": "Set free amount",
+          "exclude": "Exclude user",
+          "include": "Include user",
           "finish": "Done"
         }
       }


### PR DESCRIPTION
## Summary
- add constant for excluded users
- extend config flow to manage excluded users in options
- store excluded users in config entries
- ignore excluded users when searching for new persons
- update translations and README

## Testing
- `python -m py_compile custom_components/tally_list/*.py`

------
https://chatgpt.com/codex/tasks/task_e_687fee43baf0832e8171b4dbe06430e6