### PR TITLE
Configure options only on price list entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The integration allows you to manage drink tallies for multiple persons from Hom
 
 ## Usage
 
-When the integration is first set up, all persons with a user account are added and you will be asked to enter the available drinks. All further persons will automatically use this list. Drinks can later be managed from the integration options where you can add, remove or edit their prices. Call the service `tally_list.add_drink` with parameters `user` and `drink` to increment the counter. Use `tally_list.adjust_count` with `count` to set an exact value. To decrement by one call `tally_list.remove_drink` with `user` and `drink`. Use the reset button entity to reset all counters.
+When the integration is first set up, all persons with a user account are added and you will be asked to enter the available drinks. All further persons will automatically use this list. Drinks can later be managed from the integration options of the dedicated `Preisliste` entry where you can add, remove or edit their prices. Call the service `tally_list.add_drink` with parameters `user` and `drink` to increment the counter. Use `tally_list.adjust_count` with `count` to set an exact value. To decrement by one call `tally_list.remove_drink` with `user` and `drink`. Use the reset button entity to reset all counters.
 
 ## Price List and Sensors
 
@@ -32,4 +32,4 @@ All drinks are stored in a single price list. A dedicated user named
 exposes one price sensor per drink as well as a free amount sensor while regular
 persons only get count and total amount sensors. The free amount is subtracted from
 each person's total. You can edit the drinks, prices and free amount at any time
-from the integration options.
+from the integration options of this `Preisliste` entry.

--- a/custom_components/tally_list/config_flow.py
+++ b/custom_components/tally_list/config_flow.py
@@ -143,6 +143,8 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     @staticmethod
     @callback
     def async_get_options_flow(config_entry):
+        if config_entry.data.get(CONF_USER) != PRICE_LIST_USER:
+            return None
         return TallyListOptionsFlowHandler(config_entry)
 
 

--- a/custom_components/tally_list/manifest.json
+++ b/custom_components/tally_list/manifest.json
@@ -2,7 +2,7 @@
   "domain": "tally_list",
   "name": "Tally List",
   "documentation": "https://github.com/example/ha-drink-counter",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "requirements": [],
   "icon": "mdi:glass-mug",
   "config_flow": true,


### PR DESCRIPTION
## Summary
- disable options flow for regular user entries
- document that settings are accessed from the `Preisliste` entry
- bump integration version to 1.0.1

## Testing
- `python -m compileall -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fed8b6c84832eb606982db9528cc4