### PR TITLE
Update options to use list menu

### DIFF
--- a/custom_components/tally_list/config_flow.py
+++ b/custom_components/tally_list/config_flow.py
@@ -178,37 +178,32 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
 
     async def async_step_menu(self, user_input=None):
         if user_input is not None:
-            action = user_input["action"]
-            if action == "add":
+            if user_input == "add":
                 return await self.async_step_add_drink()
-            if action == "remove":
+            if user_input == "remove":
                 return await self.async_step_remove_drink()
-            if action == "edit":
+            if user_input == "edit":
                 return await self.async_step_edit_price()
-            if action == "free_amount":
+            if user_input == "free_amount":
                 return await self.async_step_set_free_amount()
-            if action == "exclude":
+            if user_input == "exclude":
                 return await self.async_step_add_excluded_user()
-            if action == "include":
+            if user_input == "include":
                 return await self.async_step_remove_excluded_user()
-            if action == "finish":
+            if user_input == "finish":
                 return await self._update_drinks()
-        schema = vol.Schema(
-            {
-                vol.Required("action"): vol.In(
-                    [
-                        "add",
-                        "remove",
-                        "edit",
-                        "free_amount",
-                        "exclude",
-                        "include",
-                        "finish",
-                    ]
-                ),
-            }
+        return self.async_show_menu(
+            step_id="menu",
+            menu_options=[
+                "add",
+                "remove",
+                "edit",
+                "free_amount",
+                "exclude",
+                "include",
+                "finish",
+            ],
         )
-        return self.async_show_form(step_id="menu", data_schema=schema)
 
     async def async_step_add_drink(self, user_input=None):
         if user_input is not None:

--- a/custom_components/tally_list/translations/de.json
+++ b/custom_components/tally_list/translations/de.json
@@ -26,8 +26,14 @@
       "step": {
         "menu": {
           "title": "Getränke verwalten",
-          "data": {
-            "action": "Aktion"
+          "menu_options": {
+            "add": "Hinzufügen",
+            "remove": "Entfernen",
+            "edit": "Bearbeiten",
+            "free_amount": "Freibetrag",
+            "exclude": "Ausschließen",
+            "include": "Einschließen",
+            "finish": "Fertig"
           }
         },
         "add_drink": {

--- a/custom_components/tally_list/translations/en.json
+++ b/custom_components/tally_list/translations/en.json
@@ -26,8 +26,14 @@
       "step": {
         "menu": {
           "title": "Manage Drinks",
-          "data": {
-            "action": "Action"
+          "menu_options": {
+            "add": "Add drink",
+            "remove": "Remove drink",
+            "edit": "Edit price",
+            "free_amount": "Set free amount",
+            "exclude": "Exclude user",
+            "include": "Include user",
+            "finish": "Done"
           }
         },
         "add_drink": {


### PR DESCRIPTION
## Summary
- show the options step as a click list instead of a dropdown
- update translations to include menu options

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ff3c18e24832ea984795590970cf7