### PR TITLE
Group additional users under main integration

### DIFF
--- a/custom_components/tally_list/config_flow.py
+++ b/custom_components/tally_list/config_flow.py
@@ -17,6 +17,7 @@ from .const import (
     CONF_PRICE,
     CONF_FREE_AMOUNT,
     CONF_EXCLUDED_USERS,
+    CONF_USES,
     PRICE_LIST_USER,
 )
 
@@ -46,6 +47,7 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._drinks: dict[str, float] = {}
         self._free_amount: float = 0.0
         self._excluded_users: list[str] = []
+        self._parent_entry_id: str | None = None
 
     async def async_step_import(self, user_input=None):
         """Handle import of a config entry."""
@@ -55,6 +57,7 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._drinks = user_input.get(CONF_DRINKS, {})
         self._free_amount = float(user_input.get(CONF_FREE_AMOUNT, 0.0))
         self._excluded_users = user_input.get(CONF_EXCLUDED_USERS, [])
+        self._parent_entry_id = user_input.get(CONF_USES)
         return self.async_create_entry(title=self._user, data=user_input)
 
     async def async_step_user(self, user_input=None):
@@ -88,24 +91,35 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="no_users")
 
         self._user = persons[0]
-        for p in persons[1:]:
-            self.hass.async_create_task(
-                self.hass.config_entries.flow.async_init(
-                    DOMAIN,
-                    context={"source": config_entries.SOURCE_IMPORT},
-                    data={CONF_USER: p},
-                )
-            )
 
         entries = self.hass.config_entries.async_entries(DOMAIN)
         for entry in entries:
             if CONF_DRINKS in entry.data:
                 self._drinks = entry.data[CONF_DRINKS]
                 self._excluded_users = entry.data.get(CONF_EXCLUDED_USERS, [])
-                return self.async_create_entry(
-                    title=self._user,
-                    data={CONF_USER: self._user},
+                self._parent_entry_id = entry.entry_id
+                break
+
+        for p in persons[1:]:
+            data = {CONF_USER: p}
+            if self._parent_entry_id:
+                data[CONF_USES] = self._parent_entry_id
+            self.hass.async_create_task(
+                self.hass.config_entries.flow.async_init(
+                    DOMAIN,
+                    context={"source": config_entries.SOURCE_IMPORT},
+                    data=data,
                 )
+            )
+
+        if self._parent_entry_id:
+            return self.async_create_entry(
+                title=self._user,
+                data={
+                    CONF_USER: self._user,
+                    CONF_USES: self._parent_entry_id,
+                },
+            )
 
         return await self.async_step_add_drink()
 

--- a/custom_components/tally_list/const.py
+++ b/custom_components/tally_list/const.py
@@ -17,3 +17,6 @@ SERVICE_RESET_COUNTERS = "reset_counters"
 
 # Dedicated user name that exposes drink prices
 PRICE_LIST_USER = "Preisliste"
+
+# Identifier to mark sub entries that use the connection of the parent entry.
+CONF_USES = "uses"


### PR DESCRIPTION
## Summary
- add `CONF_USES` constant
- create sub entries that reference the parent entry id

## Testing
- `python -m py_compile custom_components/tally_list/*.py`

------
https://chatgpt.com/codex/tasks/task_e_687ff4ede58c832e8bdc7029719349ec