### PR TITLE
Group additional users under main integration

### DIFF
--- a/custom_components/tally_list/const.py
+++ b/custom_components/tally_list/const.py
@@ -17,3 +17,6 @@ SERVICE_RESET_COUNTERS = "reset_counters"
 
 # Dedicated user name that exposes drink prices
 PRICE_LIST_USER = "Preisliste"
+
+# Identifier to mark sub entries that use the connection of the parent entry.
+CONF_USES = "uses"


### PR DESCRIPTION
## Summary
- add `CONF_USES` constant
- create sub entries that reference the parent entry id
- pass `uses` parameter when creating entries so HA groups them

## Testing
- `python -m py_compile custom_components/tally_list/*.py`


------
https://chatgpt.com/codex/tasks/task_e_687ff4ede58c832e8bdc7029719349ec