### PR TITLE
Switch options menu to vertical selector

### DIFF
--- a/custom_components/tally_list/config_flow.py
+++ b/custom_components/tally_list/config_flow.py
@@ -209,38 +209,39 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
         return await self.async_step_menu()
 
     async def async_step_menu(self, user_input=None):
-        if user_input is not None:
-            action = user_input["action"]
-            if action == "add":
-                return await self.async_step_add_drink()
-            if action == "remove":
-                return await self.async_step_remove_drink()
-            if action == "edit":
-                return await self.async_step_edit_price()
-            if action == "free_amount":
-                return await self.async_step_set_free_amount()
-            if action == "exclude":
-                return await self.async_step_add_excluded_user()
-            if action == "include":
-                return await self.async_step_remove_excluded_user()
-            if action == "finish":
-                return await self._update_drinks()
-        schema = vol.Schema(
-            {
-                vol.Required("action"): vol.In(
-                    [
-                        "add",
-                        "remove",
-                        "edit",
-                        "free_amount",
-                        "exclude",
-                        "include",
-                        "finish",
-                    ]
-                ),
-            }
+        return self.async_show_menu(
+            step_id="menu",
+            menu_options=[
+                "add",
+                "remove",
+                "edit",
+                "free_amount",
+                "exclude",
+                "include",
+                "finish",
+            ],
         )
-        return self.async_show_form(step_id="menu", data_schema=schema)
+
+    async def async_step_add(self, user_input=None):
+        return await self.async_step_add_drink(user_input)
+
+    async def async_step_remove(self, user_input=None):
+        return await self.async_step_remove_drink(user_input)
+
+    async def async_step_edit(self, user_input=None):
+        return await self.async_step_edit_price(user_input)
+
+    async def async_step_free_amount(self, user_input=None):
+        return await self.async_step_set_free_amount(user_input)
+
+    async def async_step_exclude(self, user_input=None):
+        return await self.async_step_add_excluded_user(user_input)
+
+    async def async_step_include(self, user_input=None):
+        return await self.async_step_remove_excluded_user(user_input)
+
+    async def async_step_finish(self, user_input=None):
+        return await self._update_drinks()
 
     async def async_step_add_drink(self, user_input=None):
         if user_input is not None:

--- a/custom_components/tally_list/translations/de.json
+++ b/custom_components/tally_list/translations/de.json
@@ -26,8 +26,14 @@
       "step": {
         "menu": {
           "title": "Getränke verwalten",
-          "data": {
-            "action": "Aktion"
+          "menu_options": {
+            "add": "Hinzufügen",
+            "remove": "Entfernen",
+            "edit": "Bearbeiten",
+            "free_amount": "Freibetrag",
+            "exclude": "Ausschließen",
+            "include": "Einschließen",
+            "finish": "Fertig"
           }
         },
         "add_drink": {

--- a/custom_components/tally_list/translations/en.json
+++ b/custom_components/tally_list/translations/en.json
@@ -26,8 +26,14 @@
       "step": {
         "menu": {
           "title": "Manage Drinks",
-          "data": {
-            "action": "Action"
+          "menu_options": {
+            "add": "Add drink",
+            "remove": "Remove drink",
+            "edit": "Edit price",
+            "free_amount": "Set free amount",
+            "exclude": "Exclude user",
+            "include": "Include user",
+            "finish": "Done"
           }
         },
         "add_drink": {


### PR DESCRIPTION
## Summary
- show options flow menu with `async_show_menu` instead of a dropdown
- connect menu options to existing steps
- localize actions in `menu_options`

## Testing
- `python -m py_compile custom_components/tally_list/config_flow.py`
- `python -m json.tool custom_components/tally_list/translations/en.json`
- `python -m json.tool custom_components/tally_list/translations/de.json`


------
https://chatgpt.com/codex/tasks/task_e_688131dd7dd0832ebda49c2cc188ba82