### PR TITLE
Improve reset button naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The integration allows you to manage drink tallies for multiple persons from Hom
 
 ## Usage
 
-When the integration is first set up, all persons with a user account are added and you will be asked to enter the available drinks. All further persons will automatically use this list. Drinks can later be managed from the integration options where you can add, remove or edit their prices. Call the service `tally_list.add_drink` with parameters `user` and `drink` to increment the counter. Use `tally_list.adjust_count` with `count` to set an exact value. To decrement by one call `tally_list.remove_drink` with `user` and `drink`. Use the reset button entity to reset all counters.
+When the integration is first set up, all persons with a user account are added and you will be asked to enter the available drinks. All further persons will automatically use this list. Drinks can later be managed from the integration options where you can add, remove or edit their prices. Call the service `tally_list.add_drink` with parameters `user` and `drink` to increment the counter. Use `tally_list.adjust_count` with `count` to set an exact value. To decrement by one call `tally_list.remove_drink` with `user` and `drink`. Use the reset button entity to reset all counters. The reset button entity ID follows `button.<person>_reset_tally`, so you can match all reset buttons with `button.*_reset_tally`.
 
 ## Price List and Sensors
 

--- a/custom_components/tally_list/button.py
+++ b/custom_components/tally_list/button.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from homeassistant.components.button import ButtonEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.util import slugify
 
 from .const import (
     DOMAIN,
@@ -25,8 +26,10 @@ class ResetButton(ButtonEntity):
     def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
         self._hass = hass
         self._entry = entry
-        self._attr_name = f"{entry.data[CONF_USER]} Reset"
-        self._attr_unique_id = f"{entry.entry_id}_reset"
+        user = entry.data[CONF_USER]
+        self._attr_name = f"{user} Reset"
+        self._attr_unique_id = f"{entry.entry_id}_reset_tally"
+        self.entity_id = f"button.{slugify(user)}_reset_tally"
 
     async def async_press(self) -> None:
         await self._hass.services.async_call(


### PR DESCRIPTION
## Summary
- use `_reset_tally` at the end of reset button ids
- document the new pattern in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68813adace58832e883ea78a59f1a42b