### PR TITLE
Convert finish option to a button

### DIFF
--- a/custom_components/tally_list/config_flow.py
+++ b/custom_components/tally_list/config_flow.py
@@ -241,7 +241,9 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
         return await self.async_step_remove_excluded_user(user_input)
 
     async def async_step_finish(self, user_input=None):
-        return await self._update_drinks()
+        if user_input is not None:
+            return await self._update_drinks()
+        return self.async_show_form(step_id="finish", last_step=True)
 
     async def async_step_add_drink(self, user_input=None):
         if user_input is not None:

--- a/custom_components/tally_list/translations/de.json
+++ b/custom_components/tally_list/translations/de.json
@@ -79,6 +79,9 @@
             "user": "Nutzer",
             "remove_more": "Weiteren einschließen"
           }
+        },
+        "finish": {
+          "title": "Fertig"
         }
       },
       "enum": {

--- a/custom_components/tally_list/translations/en.json
+++ b/custom_components/tally_list/translations/en.json
@@ -79,6 +79,9 @@
             "user": "User",
             "remove_more": "Include another"
           }
+        },
+        "finish": {
+          "title": "Done"
         }
       },
       "enum": {


### PR DESCRIPTION
## Summary
- show a form for the `finish` step so that it is displayed as a button
- add translations for the new finish step

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883a7086fb8832e91b34828a74a7399