### PR TITLE
Change finish menu option to finish button

### DIFF
--- a/custom_components/tally_list/config_flow.py
+++ b/custom_components/tally_list/config_flow.py
@@ -17,6 +17,7 @@ from .const import (
     CONF_PRICE,
     CONF_FREE_AMOUNT,
     CONF_EXCLUDED_USERS,
+    CONF_ACTION,
     PRICE_LIST_USER,
 )
 
@@ -209,17 +210,25 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
         return await self.async_step_menu()
 
     async def async_step_menu(self, user_input=None):
-        return self.async_show_menu(
+        if user_input is not None:
+            action: str | None = user_input.get(CONF_ACTION)
+            if not action:
+                return await self._update_drinks()
+            return await getattr(self, f"async_step_{action}")()
+
+        schema = vol.Schema({vol.Optional(CONF_ACTION): vol.In([
+            "add",
+            "remove",
+            "edit",
+            "free_amount",
+            "exclude",
+            "include",
+        ])})
+
+        return self.async_show_form(
             step_id="menu",
-            menu_options=[
-                "add",
-                "remove",
-                "edit",
-                "free_amount",
-                "exclude",
-                "include",
-                "finish",
-            ],
+            data_schema=schema,
+            last_step=True,
         )
 
     async def async_step_add(self, user_input=None):

--- a/custom_components/tally_list/const.py
+++ b/custom_components/tally_list/const.py
@@ -6,6 +6,7 @@ CONF_DRINK = "drink"
 CONF_PRICE = "price"
 CONF_FREE_AMOUNT = "free_amount"
 CONF_EXCLUDED_USERS = "excluded_users"
+CONF_ACTION = "action"
 
 ATTR_USER = "user"
 ATTR_DRINK = "drink"

--- a/custom_components/tally_list/translations/de.json
+++ b/custom_components/tally_list/translations/de.json
@@ -27,14 +27,16 @@
       "step": {
         "menu": {
           "title": "Getränke verwalten",
+          "data": {
+            "action": "Aktion"
+          },
           "menu_options": {
             "add": "Hinzufügen",
             "remove": "Entfernen",
             "edit": "Bearbeiten",
             "free_amount": "Freibetrag",
             "exclude": "Ausschließen",
-            "include": "Einschließen",
-            "finish": "Fertig"
+            "include": "Einschließen"
           }
         },
         "add_drink": {

--- a/custom_components/tally_list/translations/en.json
+++ b/custom_components/tally_list/translations/en.json
@@ -27,14 +27,16 @@
     "step": {
         "menu": {
           "title": "Manage Drinks",
+          "data": {
+            "action": "Action"
+          },
           "menu_options": {
             "add": "Add drink",
             "remove": "Remove drink",
             "edit": "Edit price",
             "free_amount": "Set free amount",
             "exclude": "Exclude user",
-            "include": "Include user",
-            "finish": "Done"
+            "include": "Include user"
           }
         },
         "add_drink": {


### PR DESCRIPTION
## Summary
- add `CONF_ACTION` constant
- replace menu with form that has a Finish button
- update translations for new action field

## Testing
- `python -m py_compile custom_components/tally_list/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6883a911417c832e98881045075ca82c