### PR TITLE
Adjust sensor names and use euro unit

### DIFF
--- a/custom_components/tally_list/sensor.py
+++ b/custom_components/tally_list/sensor.py
@@ -47,6 +47,7 @@ class TallyListSensor(RestoreEntity, SensorEntity):
         self._attr_name = f"{entry.data[CONF_USER]} {drink} Count"
         self._attr_unique_id = f"{entry.entry_id}_{drink}_count"
         self._attr_native_value = 0
+        self._attr_native_unit_of_measurement = "€"
 
     async def async_added_to_hass(self) -> None:
         last_state = await self.async_get_last_state()
@@ -93,7 +94,7 @@ class DrinkPriceSensor(SensorEntity):
         self._attr_should_poll = False
         self._attr_name = f"{entry.data[CONF_USER]} {drink} Price"
         self._attr_unique_id = f"{entry.entry_id}_{drink}_price"
-        self._attr_unit_of_measurement = "EUR"
+        self._attr_native_unit_of_measurement = "€"
 
     async def async_added_to_hass(self) -> None:
         await self.async_update_state()
@@ -114,7 +115,7 @@ class FreeAmountSensor(SensorEntity):
         self._attr_should_poll = False
         self._attr_name = f"{entry.data[CONF_USER]} Free Amount"
         self._attr_unique_id = f"{entry.entry_id}_free_amount"
-        self._attr_unit_of_measurement = "EUR"
+        self._attr_native_unit_of_measurement = "€"
 
     async def async_added_to_hass(self) -> None:
         await self.async_update_state()
@@ -132,9 +133,9 @@ class TotalAmountSensor(RestoreEntity, SensorEntity):
         self._hass = hass
         self._entry = entry
         self._attr_should_poll = False
-        self._attr_name = f"{entry.data[CONF_USER]} Amount Due"
+        self._attr_name = entry.data[CONF_USER]
         self._attr_unique_id = f"{entry.entry_id}_amount_due"
-        self._attr_unit_of_measurement = "EUR"
+        self._attr_native_unit_of_measurement = "€"
         self._attr_native_value = 0
 
     async def async_added_to_hass(self) -> None:


### PR DESCRIPTION
## Summary
- tweak sensor names
- set native unit of measurement to Euro for all sensors

## Testing
- `python -m compileall -q custom_components/tally_list/sensor.py`


------
https://chatgpt.com/codex/tasks/task_e_6883ab86bb90832ea72af0f7883781f9