### PR TITLE
Restore total amount sensor name

### DIFF
--- a/custom_components/tally_list/sensor.py
+++ b/custom_components/tally_list/sensor.py
@@ -133,7 +133,7 @@ class TotalAmountSensor(RestoreEntity, SensorEntity):
         self._hass = hass
         self._entry = entry
         self._attr_should_poll = False
-        self._attr_name = entry.data[CONF_USER]
+        self._attr_name = f"{entry.data[CONF_USER]} Amount Due"
         self._attr_unique_id = f"{entry.entry_id}_amount_due"
         self._attr_native_unit_of_measurement = "€"
         self._attr_native_value = 0


### PR DESCRIPTION
## Summary
- fix the total amount sensor name so entity IDs match `*_amount_due`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6883b8df96ac832ea7f3b76fbaa7161d