### PR TITLE
Implement parent/child devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ The integration allows you to manage drink tallies for multiple persons from Hom
 - Persons with user accounts are added automatically. Drinks are added only once with a name and price and are available for every person.
 - Sensor entities for each drink's count, each drink's price, a free amount sensor, and a sensor showing the total amount a person has to pay.
 - Button entity to reset all counters for a person.
+- Entities for each user are now grouped under a device.
+  These devices are linked to the price list device using Home Assistant's
+  parent device feature.
 - Service `tally_list.add_drink` to add a drink for a person.
 - Service `tally_list.remove_drink` to remove a drink for a person.
 - Service `tally_list.adjust_count` to set a drink count to a specific value.

--- a/custom_components/tally_list/button.py
+++ b/custom_components/tally_list/button.py
@@ -13,6 +13,7 @@ from .const import (
     CONF_USER,
     PRICE_LIST_USER,
 )
+from .helpers import device_info_for_entry
 
 
 async def async_setup_entry(
@@ -30,6 +31,7 @@ class ResetButton(ButtonEntity):
         self._attr_name = f"{user} Reset"
         self._attr_unique_id = f"{entry.entry_id}_reset_tally"
         self.entity_id = f"button.{slugify(user)}_reset_tally"
+        self._attr_device_info = device_info_for_entry(hass, entry)
 
     async def async_press(self) -> None:
         await self._hass.services.async_call(

--- a/custom_components/tally_list/helpers.py
+++ b/custom_components/tally_list/helpers.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+
+from .const import DOMAIN, CONF_USER, PRICE_LIST_USER
+
+
+def device_info_for_entry(hass: HomeAssistant, entry: ConfigEntry) -> DeviceInfo:
+    """Return DeviceInfo for a config entry using the price list as parent."""
+    device: DeviceInfo = {
+        "identifiers": {(DOMAIN, entry.entry_id)},
+        "name": entry.title or entry.data.get(CONF_USER),
+    }
+    if entry.data.get(CONF_USER) != PRICE_LIST_USER:
+        price_entry = next(
+            (
+                e
+                for e in hass.config_entries.async_entries(DOMAIN)
+                if e.data.get(CONF_USER) == PRICE_LIST_USER
+            ),
+            None,
+        )
+        if price_entry is not None:
+            device["via_device"] = (DOMAIN, price_entry.entry_id)
+    return device

--- a/custom_components/tally_list/sensor.py
+++ b/custom_components/tally_list/sensor.py
@@ -8,6 +8,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN, CONF_USER, PRICE_LIST_USER
+from .helpers import device_info_for_entry
 
 
 async def async_setup_entry(
@@ -48,6 +49,7 @@ class TallyListSensor(RestoreEntity, SensorEntity):
         self._attr_unique_id = f"{entry.entry_id}_{drink}_count"
         self._attr_native_value = 0
         self._attr_native_unit_of_measurement = "€"
+        self._attr_device_info = device_info_for_entry(hass, entry)
 
     async def async_added_to_hass(self) -> None:
         last_state = await self.async_get_last_state()
@@ -95,6 +97,7 @@ class DrinkPriceSensor(SensorEntity):
         self._attr_name = f"{entry.data[CONF_USER]} {drink} Price"
         self._attr_unique_id = f"{entry.entry_id}_{drink}_price"
         self._attr_native_unit_of_measurement = "€"
+        self._attr_device_info = device_info_for_entry(hass, entry)
 
     async def async_added_to_hass(self) -> None:
         await self.async_update_state()
@@ -116,6 +119,7 @@ class FreeAmountSensor(SensorEntity):
         self._attr_name = f"{entry.data[CONF_USER]} Free Amount"
         self._attr_unique_id = f"{entry.entry_id}_free_amount"
         self._attr_native_unit_of_measurement = "€"
+        self._attr_device_info = device_info_for_entry(hass, entry)
 
     async def async_added_to_hass(self) -> None:
         await self.async_update_state()
@@ -138,6 +142,7 @@ class TotalAmountSensor(RestoreEntity, SensorEntity):
         self._attr_native_unit_of_measurement = "€"
         self._attr_native_value = 0
         self._attr_suggested_display_precision = 2
+        self._attr_device_info = device_info_for_entry(hass, entry)
 
     async def async_added_to_hass(self) -> None:
         await self.async_update_state()


### PR DESCRIPTION
## Summary
- group sensors and buttons into devices
- link user devices to the price list device
- document device grouping in README

## Testing
- `python -m py_compile custom_components/tally_list/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6883bb2d3e88832eb2fb59a4bf956989