### PR TITLE
Update options flow menu

### DIFF
--- a/custom_components/tally_list/config_flow.py
+++ b/custom_components/tally_list/config_flow.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import voluptuous as vol
 
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.selector import selector
 
 from homeassistant import config_entries
 from homeassistant.core import callback
@@ -209,18 +210,38 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
         return await self.async_step_menu()
 
     async def async_step_menu(self, user_input=None):
-        return self.async_show_menu(
-            step_id="menu",
-            menu_options=[
-                "add",
-                "remove",
-                "edit",
-                "free_amount",
-                "exclude",
-                "include",
-                "finish",
-            ],
+        if user_input is not None:
+            if user_input.get("finish"):
+                return await self._update_drinks()
+
+            action = user_input.get("action")
+            if action:
+                return await getattr(self, f"async_step_{action}")()
+
+        options = [
+            "add",
+            "remove",
+            "edit",
+            "free_amount",
+            "exclude",
+            "include",
+        ]
+
+        schema = vol.Schema(
+            {
+                vol.Optional("action"): selector(
+                    {
+                        "select": {
+                            "options": options,
+                            "translation_key": "action",
+                        }
+                    }
+                ),
+                vol.Optional("finish"): selector({"action": {}}),
+            }
         )
+
+        return self.async_show_form(step_id="menu", data_schema=schema)
 
     async def async_step_add(self, user_input=None):
         return await self.async_step_add_drink(user_input)

--- a/custom_components/tally_list/translations/de.json
+++ b/custom_components/tally_list/translations/de.json
@@ -33,8 +33,7 @@
             "edit": "Bearbeiten",
             "free_amount": "Freibetrag",
             "exclude": "Ausschließen",
-            "include": "Einschließen",
-            "finish": "Fertig"
+            "include": "Einschließen"
           }
         },
         "add_drink": {

--- a/custom_components/tally_list/translations/en.json
+++ b/custom_components/tally_list/translations/en.json
@@ -33,8 +33,7 @@
             "edit": "Edit price",
             "free_amount": "Set free amount",
             "exclude": "Exclude user",
-            "include": "Include user",
-            "finish": "Done"
+            "include": "Include user"
           }
         },
         "add_drink": {


### PR DESCRIPTION
## Summary
- move finish action to a button in the options flow
- remove `finish` from dropdown translations

## Testing
- `python -m py_compile custom_components/tally_list/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6883bfa27078832e9bc1b50618bd3ad7