### PR TITLE
Fix cleanup error

### DIFF
--- a/custom_components/tally_list/config_flow.py
+++ b/custom_components/tally_list/config_flow.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import voluptuous as vol
 
 from homeassistant.helpers import entity_registry as er
+from homeassistant.components import persistent_notification
 
 from homeassistant import config_entries
 from homeassistant.core import callback
@@ -214,6 +215,7 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
             menu_options=[
                 "add",
                 "remove",
+                "cleanup_sensors",
                 "edit",
                 "free_amount",
                 "exclude",
@@ -227,6 +229,70 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
 
     async def async_step_remove(self, user_input=None):
         return await self.async_step_remove_drink(user_input)
+
+    async def async_step_cleanup_sensors(self, user_input=None):
+        await self._cleanup_sensors()
+        return await self.async_step_menu()
+
+    async def _cleanup_sensors(self):
+        registry = er.async_get(self.hass)
+        entries = self.hass.config_entries.async_entries(DOMAIN)
+        entry_ids = {entry.entry_id for entry in entries}
+        active_users = {entry.data.get(CONF_USER) for entry in entries}
+        active_drinks = set(self._drinks.keys())
+
+        removed = False
+        for entity_id, entry in list(registry.entities.items()):
+            if entry.domain != "sensor" or entry.platform != DOMAIN:
+                continue
+            if entry.config_entry_id not in entry_ids:
+                await registry.async_remove(entity_id)
+                removed = True
+                continue
+            config_entry = next(
+                (
+                    e
+                    for e in entries
+                    if e.entry_id == entry.config_entry_id
+                ),
+                None,
+            )
+            if not config_entry:
+                await registry.async_remove(entity_id)
+                removed = True
+                continue
+            user = config_entry.data.get(CONF_USER)
+            if user not in active_users:
+                await registry.async_remove(entity_id)
+                removed = True
+                continue
+            uid = entry.unique_id or ""
+            suffixes = {"_count", "_price"}
+            drink = None
+            for suffix in suffixes:
+                if uid.endswith(suffix):
+                    base = uid[:-len(suffix)]
+                    prefix = f"{config_entry.entry_id}_"
+                    if base.startswith(prefix):
+                        drink = base[len(prefix):]
+                    break
+            if drink is not None and drink not in active_drinks:
+                await registry.async_remove(entity_id)
+                removed = True
+
+        if removed:
+            for cfg_entry in entries:
+                self.hass.async_create_task(
+                    self.hass.config_entries.async_reload(cfg_entry.entry_id)
+                )
+            await persistent_notification.async_create(
+                self.hass,
+                (
+                    "Unused sensors have been removed. "
+                    "This also resets stored 'amount due' values."
+                ),
+                title="Tally List",
+            )
 
     async def async_step_edit(self, user_input=None):
         return await self.async_step_edit_price(user_input)
@@ -263,18 +329,29 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
 
     async def async_step_remove_drink(self, user_input=None):
         if user_input is not None:
-            drink = user_input[CONF_DRINK]
-            self._drinks.pop(drink, None)
+            drink = user_input.get(CONF_DRINK)
+            cleanup = user_input.get("cleanup_sensors")
+            if drink:
+                self._drinks.pop(drink, None)
+            if cleanup:
+                await self._cleanup_sensors()
             if user_input.get("remove_more") and self._drinks:
                 return await self.async_step_remove_drink()
             return await self.async_step_menu()
 
         if not self._drinks:
-            return await self.async_step_menu()
+            schema = vol.Schema(
+                {vol.Optional("cleanup_sensors", default=False): bool}
+            )
+            return self.async_show_form(
+                step_id="remove_drink",
+                data_schema=schema,
+            )
 
         schema = vol.Schema(
             {
-                vol.Required(CONF_DRINK): vol.In(list(self._drinks.keys())),
+                vol.Optional(CONF_DRINK): vol.In(list(self._drinks.keys())),
+                vol.Optional("cleanup_sensors", default=False): bool,
                 vol.Optional("remove_more", default=False): bool,
             }
         )

--- a/custom_components/tally_list/translations/de.json
+++ b/custom_components/tally_list/translations/de.json
@@ -30,6 +30,7 @@
           "menu_options": {
             "add": "Hinzufügen",
             "remove": "Entfernen",
+            "cleanup_sensors": "Sensoren bereinigen",
             "edit": "Bearbeiten",
             "free_amount": "Freibetrag",
             "exclude": "Ausschließen",
@@ -49,8 +50,13 @@
           "title": "Getränk entfernen",
           "data": {
             "drink": "Getränk",
+            "cleanup_sensors": "Sensoren bereinigen",
             "remove_more": "Weiteres entfernen"
           }
+        },
+        "cleanup_sensors": {
+          "title": "Sensoren bereinigen",
+          "description": "Das Löschen der Sensoren entfernt auch gespeicherte 'zu zahlen' Beträge"
         },
         "edit_price": {
           "title": "Preis bearbeiten",

--- a/custom_components/tally_list/translations/en.json
+++ b/custom_components/tally_list/translations/en.json
@@ -30,6 +30,7 @@
           "menu_options": {
             "add": "Add drink",
             "remove": "Remove drink",
+            "cleanup_sensors": "Cleanup sensors",
             "edit": "Edit price",
             "free_amount": "Set free amount",
             "exclude": "Exclude user",
@@ -49,8 +50,13 @@
           "title": "Remove Drink",
           "data": {
             "drink": "Drink",
+            "cleanup_sensors": "Cleanup sensors",
             "remove_more": "Remove another"
           }
+        },
+        "cleanup_sensors": {
+          "title": "Cleanup Sensors",
+          "description": "Removing sensors resets stored amounts due"
         },
         "edit_price": {
           "title": "Edit Price",


### PR DESCRIPTION
## Summary
- reload entries asynchronously to avoid aborting the flow
- notify via `persistent_notification.async_create`
- fix whitespace and line length issues in config_flow

## Testing
- `python -m py_compile custom_components/tally_list/*.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6883c4f3a578832e85362ea697087818