### PR TITLE
Add cleanup sensors option

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The integration allows you to manage drink tallies for multiple persons from Hom
 - Service `tally_list.adjust_count` to set a drink count to a specific value.
 - Counters cannot go below zero when removing drinks.
 - Exclude persons from automatic import via the integration options.
+- Remove unused sensors from the options menu.
 
 ## Installation
 
@@ -24,7 +25,7 @@ The integration allows you to manage drink tallies for multiple persons from Hom
 
 ## Usage
 
-When the integration is first set up, all persons with a user account are added and you will be asked to enter the available drinks. All further persons will automatically use this list. Drinks can later be managed from the integration options where you can add, remove or edit their prices. Call the service `tally_list.add_drink` with parameters `user` and `drink` to increment the counter. Use `tally_list.adjust_count` with `count` to set an exact value. To decrement by one call `tally_list.remove_drink` with `user` and `drink`. Use the reset button entity to reset all counters. The reset button entity ID follows `button.<person>_reset_tally`, so you can match all reset buttons with `button.*_reset_tally`.
+When the integration is first set up, all persons with a user account are added and you will be asked to enter the available drinks. All further persons will automatically use this list. Drinks can later be managed from the integration options where you can add, remove or edit their prices. Call the service `tally_list.add_drink` with parameters `user` and `drink` to increment the counter. Use `tally_list.adjust_count` with `count` to set an exact value. To decrement by one call `tally_list.remove_drink` with `user` and `drink`. Use the reset button entity to reset all counters. The reset button entity ID follows `button.<person>_reset_tally`, so you can match all reset buttons with `button.*_reset_tally`. Use the **Cleanup sensors** option in the integration settings to remove entities for drinks that no longer exist.
 
 ## Price List and Sensors
 

--- a/custom_components/tally_list/config_flow.py
+++ b/custom_components/tally_list/config_flow.py
@@ -214,6 +214,7 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
             menu_options=[
                 "add",
                 "remove",
+                "cleanup_sensors",
                 "edit",
                 "free_amount",
                 "exclude",
@@ -227,6 +228,10 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
 
     async def async_step_remove(self, user_input=None):
         return await self.async_step_remove_drink(user_input)
+
+    async def async_step_cleanup_sensors(self, user_input=None):
+        await self._cleanup_sensors()
+        return await self.async_step_menu()
 
     async def async_step_edit(self, user_input=None):
         return await self.async_step_edit_price(user_input)
@@ -378,6 +383,54 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
             step_id="remove_excluded_user",
             data_schema=schema,
         )
+
+    async def _cleanup_sensors(self) -> None:
+        registry = er.async_get(self.hass)
+        entries = self.hass.config_entries.async_entries(DOMAIN)
+        entry_ids = {entry.entry_id for entry in entries}
+        active_users = {entry.data.get(CONF_USER) for entry in entries}
+        active_drinks = set(self._drinks.keys())
+
+        removed = False
+        for entity_entry in list(registry.entities.values()):
+            if entity_entry.domain != "sensor" or entity_entry.platform != DOMAIN:
+                continue
+            if entity_entry.config_entry_id not in entry_ids:
+                await registry.async_remove(entity_entry.entity_id)
+                removed = True
+                continue
+            cfg_entry = next(
+                (e for e in entries if e.entry_id == entity_entry.config_entry_id),
+                None,
+            )
+            if not cfg_entry:
+                await registry.async_remove(entity_entry.entity_id)
+                removed = True
+                continue
+            user = cfg_entry.data.get(CONF_USER)
+            if user not in active_users:
+                await registry.async_remove(entity_entry.entity_id)
+                removed = True
+                continue
+            uid = entity_entry.unique_id or ""
+            prefix = f"{cfg_entry.entry_id}_"
+            if not uid.startswith(prefix):
+                continue
+            if uid.endswith("_count"):
+                drink = uid[len(prefix):-6]
+            elif uid.endswith("_price"):
+                drink = uid[len(prefix):-6]
+            else:
+                continue
+            if drink not in active_drinks:
+                await registry.async_remove(entity_entry.entity_id)
+                removed = True
+
+        if removed:
+            for entry in entries:
+                self.hass.async_create_task(
+                    self.hass.config_entries.async_reload(entry.entry_id)
+                )
 
     async def _update_drinks(self):
         # Update global drinks list before reloading entries so that new

--- a/custom_components/tally_list/manifest.json
+++ b/custom_components/tally_list/manifest.json
@@ -2,7 +2,7 @@
   "domain": "tally_list",
   "name": "Tally List",
   "documentation": "https://github.com/Spider19996/ha-tally-list",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "requirements": [],
   "config_flow": true,
   "codeowners": []

--- a/custom_components/tally_list/translations/de.json
+++ b/custom_components/tally_list/translations/de.json
@@ -30,6 +30,7 @@
           "menu_options": {
             "add": "Hinzufügen",
             "remove": "Entfernen",
+            "cleanup_sensors": "Sensoren bereinigen",
             "edit": "Bearbeiten",
             "free_amount": "Freibetrag",
             "exclude": "Ausschließen",
@@ -89,6 +90,7 @@
           "free_amount": "Freibetrag",
           "exclude": "Ausschließen",
           "include": "Einschließen",
+          "cleanup_sensors": "Sensoren bereinigen",
           "finish": "Fertig"
         }
       }

--- a/custom_components/tally_list/translations/en.json
+++ b/custom_components/tally_list/translations/en.json
@@ -30,6 +30,7 @@
           "menu_options": {
             "add": "Add drink",
             "remove": "Remove drink",
+            "cleanup_sensors": "Cleanup sensors",
             "edit": "Edit price",
             "free_amount": "Set free amount",
             "exclude": "Exclude user",
@@ -89,6 +90,7 @@
           "free_amount": "Set free amount",
           "exclude": "Exclude user",
           "include": "Include user",
+          "cleanup_sensors": "Cleanup sensors",
           "finish": "Done"
         }
       }


### PR DESCRIPTION
## Summary
- add new menu entry to clean up unused sensors
- update translations and docs
- bump integration version

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688498b8676c832eb39cf296f0d91c95