### PR TITLE
Add sensor cleanup option to options flow

### DIFF
--- a/custom_components/tally_list/translations/de.json
+++ b/custom_components/tally_list/translations/de.json
@@ -79,6 +79,9 @@
             "user": "Nutzer",
             "remove_more": "Weiteren einschließen"
           }
+        },
+        "cleanup": {
+          "title": "Nicht mehr genutzte Sensoren entfernen"
         }
       },
       "enum": {
@@ -89,6 +92,7 @@
           "free_amount": "Freibetrag",
           "exclude": "Ausschließen",
           "include": "Einschließen",
+          "cleanup": "Nicht mehr genutzte Sensoren entfernen",
           "finish": "Fertig"
         }
       }

--- a/custom_components/tally_list/translations/en.json
+++ b/custom_components/tally_list/translations/en.json
@@ -79,6 +79,9 @@
             "user": "User",
             "remove_more": "Include another"
           }
+        },
+        "cleanup": {
+          "title": "Remove unused sensors"
         }
       },
       "enum": {
@@ -89,6 +92,7 @@
           "free_amount": "Set free amount",
           "exclude": "Exclude user",
           "include": "Include user",
+          "cleanup": "Remove unused sensors",
           "finish": "Done"
         }
       }


### PR DESCRIPTION
## Summary
- add new `cleanup` option in the options flow
- remove unused entities using the entity registry when the option is selected
- update English and German translations

## Testing
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_6884df3cd178832eb3a0ea374fb405e2