### PR TITLE
Show cleanup results as popup

### DIFF
--- a/custom_components/tally_list/translations/de.json
+++ b/custom_components/tally_list/translations/de.json
@@ -83,6 +83,10 @@
         },
         "cleanup": {
           "title": "Nicht mehr genutzte Sensoren entfernen"
+        },
+        "cleanup_result": {
+          "title": "Nicht genutzte Sensoren entfernt",
+          "description": "Folgende Sensoren wurden entfernt:\n- {sensors}\nDabei wurden auch gespeicherte 'zu zahlende Betr\u00e4ge' zur\u00fcckgesetzt."
         }
       },
       "enum": {

--- a/custom_components/tally_list/translations/en.json
+++ b/custom_components/tally_list/translations/en.json
@@ -83,6 +83,10 @@
         },
         "cleanup": {
           "title": "Remove unused sensors"
+        },
+        "cleanup_result": {
+          "title": "Unused sensors removed",
+          "description": "Removed unused sensors:\n- {sensors}\nThis also resets stored 'amount due' values."
         }
       },
       "enum": {


### PR DESCRIPTION
## Summary
- show list of removed sensors directly in options flow
- add translations for new popup message

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6884e978a118832e897746f5f79c017e