### PR TITLE
Add override permission configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ The integration allows you to manage drink tallies for multiple persons from Hom
 - Service `tally_list.adjust_count` to set a drink count to a specific value.
 - Counters cannot go below zero when removing drinks.
 - Exclude persons from automatic import via the integration options.
+- Grant override permissions to selected users so they can tally drinks for
+  everyone.
 
 ## Installation
 

--- a/custom_components/tally_list/__init__.py
+++ b/custom_components/tally_list/__init__.py
@@ -18,6 +18,7 @@ from .const import (
     CONF_USER,
     CONF_FREE_AMOUNT,
     CONF_EXCLUDED_USERS,
+    CONF_OVERRIDE_USERS,
     PRICE_LIST_USER,
 )
 
@@ -26,7 +27,10 @@ PLATFORMS: list[str] = ["sensor", "button"]
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up via YAML is not supported."""
-    hass.data.setdefault(DOMAIN, {"drinks": {}, "excluded_users": []})
+    hass.data.setdefault(
+        DOMAIN,
+        {"drinks": {}, "excluded_users": [], "override_users": []},
+    )
 
     async def _verify_permissions(call, target_user: str | None) -> None:
         user_id = call.context.user_id
@@ -35,14 +39,16 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         hass_user = await hass.auth.async_get_user(user_id)
         if hass_user is None or hass_user.is_admin:
             return
-        if target_user is None:
-            raise Unauthorized
-
+        override_users = hass.data.get(DOMAIN, {}).get(CONF_OVERRIDE_USERS, [])
         person_name = None
         for state in hass.states.async_all("person"):
             if state.attributes.get("user_id") == hass_user.id:
                 person_name = state.name
                 break
+        if person_name in override_users:
+            return
+        if target_user is None:
+            raise Unauthorized
         if person_name != target_user:
             raise Unauthorized
 
@@ -145,6 +151,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             "user": entry.data.get("user"),
             CONF_FREE_AMOUNT: hass.data[DOMAIN].get("free_amount", 0.0),
             CONF_EXCLUDED_USERS: hass.data[DOMAIN].get("excluded_users", []),
+            CONF_OVERRIDE_USERS: hass.data[DOMAIN].get("override_users", []),
         }
         if "drinks" in hass.data[DOMAIN]:
             entry_data["drinks"] = hass.data[DOMAIN]["drinks"]
@@ -162,6 +169,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             "user": entry.data.get("user"),
             CONF_FREE_AMOUNT: hass.data[DOMAIN]["free_amount"],
             CONF_EXCLUDED_USERS: hass.data[DOMAIN].get("excluded_users", []),
+            CONF_OVERRIDE_USERS: hass.data[DOMAIN].get("override_users", []),
         }
         if "drinks" in hass.data[DOMAIN]:
             entry_data["drinks"] = hass.data[DOMAIN]["drinks"]
@@ -172,6 +180,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     ):
         hass.data[DOMAIN]["excluded_users"] = entry.data[CONF_EXCLUDED_USERS]
     if (
+        not hass.data[DOMAIN].get("override_users")
+        and entry.data.get(CONF_OVERRIDE_USERS) is not None
+    ):
+        hass.data[DOMAIN]["override_users"] = entry.data[CONF_OVERRIDE_USERS]
+    if (
         hass.data[DOMAIN].get("excluded_users") is not None
         and CONF_EXCLUDED_USERS not in entry.data
     ):
@@ -179,6 +192,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             "user": entry.data.get("user"),
             CONF_FREE_AMOUNT: hass.data[DOMAIN].get("free_amount", 0.0),
             CONF_EXCLUDED_USERS: hass.data[DOMAIN]["excluded_users"],
+            CONF_OVERRIDE_USERS: hass.data[DOMAIN].get("override_users", []),
+        }
+        if "drinks" in hass.data[DOMAIN]:
+            entry_data["drinks"] = hass.data[DOMAIN]["drinks"]
+        hass.config_entries.async_update_entry(entry, data=entry_data)
+    if (
+        hass.data[DOMAIN].get("override_users") is not None
+        and CONF_OVERRIDE_USERS not in entry.data
+    ):
+        entry_data = {
+            "user": entry.data.get("user"),
+            CONF_FREE_AMOUNT: hass.data[DOMAIN].get("free_amount", 0.0),
+            CONF_EXCLUDED_USERS: hass.data[DOMAIN].get("excluded_users", []),
+            CONF_OVERRIDE_USERS: hass.data[DOMAIN]["override_users"],
         }
         if "drinks" in hass.data[DOMAIN]:
             entry_data["drinks"] = hass.data[DOMAIN]["drinks"]
@@ -198,6 +225,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             hass.data[DOMAIN].pop("drinks", None)
             hass.data[DOMAIN].pop("free_amount", None)
             hass.data[DOMAIN].pop(CONF_EXCLUDED_USERS, None)
+            hass.data[DOMAIN].pop(CONF_OVERRIDE_USERS, None)
         if not any(
             isinstance(value, dict) and "entry" in value
             for value in hass.data.get(DOMAIN, {}).values()

--- a/custom_components/tally_list/const.py
+++ b/custom_components/tally_list/const.py
@@ -6,6 +6,7 @@ CONF_DRINK = "drink"
 CONF_PRICE = "price"
 CONF_FREE_AMOUNT = "free_amount"
 CONF_EXCLUDED_USERS = "excluded_users"
+CONF_OVERRIDE_USERS = "override_users"
 
 ATTR_USER = "user"
 ATTR_DRINK = "drink"

--- a/custom_components/tally_list/translations/de.json
+++ b/custom_components/tally_list/translations/de.json
@@ -34,6 +34,8 @@
             "free_amount": "Freibetrag",
             "exclude": "Ausschließen",
             "include": "Einschließen",
+            "authorize": "Berechtigen",
+            "unauthorize": "Entziehen",
             "cleanup": "Nicht mehr genutzte Sensoren entfernen",
             "finish": "Fertig"
           }
@@ -81,6 +83,20 @@
             "remove_more": "Weiteren einschließen"
           }
         },
+        "add_override_user": {
+          "title": "Nutzer berechtigen",
+          "data": {
+            "user": "Nutzer",
+            "add_more": "Weiteren berechtigen"
+          }
+        },
+        "remove_override_user": {
+          "title": "Berechtigung entziehen",
+          "data": {
+            "user": "Nutzer",
+            "remove_more": "Weiteren entziehen"
+          }
+        },
         "cleanup": {
           "title": "Nicht mehr genutzte Sensoren entfernen"
         },
@@ -97,6 +113,8 @@
           "free_amount": "Freibetrag",
           "exclude": "Ausschließen",
           "include": "Einschließen",
+          "authorize": "Berechtigen",
+          "unauthorize": "Entziehen",
           "cleanup": "Nicht mehr genutzte Sensoren entfernen",
           "finish": "Fertig"
         }

--- a/custom_components/tally_list/translations/en.json
+++ b/custom_components/tally_list/translations/en.json
@@ -34,6 +34,8 @@
             "free_amount": "Set free amount",
             "exclude": "Exclude user",
             "include": "Include user",
+            "authorize": "Authorize user",
+            "unauthorize": "Unauthorize user",
             "cleanup": "Remove unused sensors",
             "finish": "Done"
           }
@@ -81,6 +83,20 @@
             "remove_more": "Include another"
           }
         },
+        "add_override_user": {
+          "title": "Authorize User",
+          "data": {
+            "user": "User",
+            "add_more": "Authorize another"
+          }
+        },
+        "remove_override_user": {
+          "title": "Unauthorize User",
+          "data": {
+            "user": "User",
+            "remove_more": "Unauthorize another"
+          }
+        },
         "cleanup": {
           "title": "Remove unused sensors"
         },
@@ -97,6 +113,8 @@
           "free_amount": "Set free amount",
           "exclude": "Exclude user",
           "include": "Include user",
+          "authorize": "Authorize user",
+          "unauthorize": "Unauthorize user",
           "cleanup": "Remove unused sensors",
           "finish": "Done"
         }


### PR DESCRIPTION
## Summary
- allow special users to bypass role checks
- manage override users via options flow
- document override permission feature
- add translations for new menu entries

## Testing
- `python -m py_compile custom_components/tally_list/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68891edc7700832ead30eeb1c57ec722