### PR TITLE
Implement get_admins service

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The integration allows you to manage drink tallies for multiple persons from Hom
 - Exclude persons from automatic import via the integration options.
 - Grant override permissions to selected users so they can tally drinks for
   everyone.
+- Service `ha_tally_list.get_admins` to list all authorized users.
 
 ## Installation
 

--- a/custom_components/tally_list/__init__.py
+++ b/custom_components/tally_list/__init__.py
@@ -13,6 +13,7 @@ from .const import (
     SERVICE_REMOVE_DRINK,
     SERVICE_ADJUST_COUNT,
     SERVICE_RESET_COUNTERS,
+    SERVICE_GET_ADMINS,
     ATTR_USER,
     ATTR_DRINK,
     CONF_USER,
@@ -111,6 +112,12 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                 for sensor in data.get("sensors", []):
                     await sensor.async_update_state()
 
+    async def get_admins_service(call):
+        override_users = hass.data.get(DOMAIN, {}).get(CONF_OVERRIDE_USERS, [])
+        return {
+            "admins": list(override_users)
+        }
+
     hass.services.async_register(
         DOMAIN,
         SERVICE_ADD_DRINK,
@@ -133,6 +140,12 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         DOMAIN,
         SERVICE_RESET_COUNTERS,
         reset_counters_service,
+    )
+
+    hass.services.async_register(
+        "ha_tally_list",
+        SERVICE_GET_ADMINS,
+        get_admins_service,
     )
 
     return True

--- a/custom_components/tally_list/const.py
+++ b/custom_components/tally_list/const.py
@@ -15,6 +15,7 @@ SERVICE_ADD_DRINK = "add_drink"
 SERVICE_REMOVE_DRINK = "remove_drink"
 SERVICE_ADJUST_COUNT = "adjust_count"
 SERVICE_RESET_COUNTERS = "reset_counters"
+SERVICE_GET_ADMINS = "get_admins"
 
 # Dedicated user name that exposes drink prices
 PRICE_LIST_USER = "Preisliste"

--- a/custom_components/tally_list/services.yaml
+++ b/custom_components/tally_list/services.yaml
@@ -39,3 +39,6 @@ reset_counters:
       description: Person name
       example: Alice
       required: false
+get_admins:
+  name: Get admins
+  description: Return all users allowed to tally drinks for others


### PR DESCRIPTION
## Summary
- add get_admins service constant
- implement service for listing override users
- expose ha_tally_list.get_admins via Home Assistant
- document new service in README
- describe service in services.yaml

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688927111c68832eae2cef3cc5e7f1fa