### PR TITLE
Add event for get_admins service

### DIFF
--- a/custom_components/tally_list/__init__.py
+++ b/custom_components/tally_list/__init__.py
@@ -114,9 +114,12 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     async def get_admins_service(call):
         override_users = hass.data.get(DOMAIN, {}).get(CONF_OVERRIDE_USERS, [])
-        return {
-            "admins": list(override_users)
-        }
+        admins = list(override_users)
+        hass.bus.async_fire(
+            "ha_tally_list_admins",
+            {"admins": admins},
+        )
+        return {"admins": admins}
 
     hass.services.async_register(
         DOMAIN,


### PR DESCRIPTION
## Summary
- fire `ha_tally_list_admins` event when `get_admins` service is called

## Testing
- `python -m py_compile custom_components/tally_list/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68892c50c13c832ea5cf572cb7e04b22