### PR TITLE
Restrict cross-user tally permissions

### DIFF
--- a/custom_components/tally_list/__init__.py
+++ b/custom_components/tally_list/__init__.py
@@ -38,7 +38,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         if user_id is None:
             return
         hass_user = await hass.auth.async_get_user(user_id)
-        if hass_user is None or hass_user.is_admin:
+        if hass_user is None:
             return
         override_users = hass.data.get(DOMAIN, {}).get(CONF_OVERRIDE_USERS, [])
         person_name = None


### PR DESCRIPTION
## Summary
- remove automatic admin override so only explicitly authorized users can add tallies for others

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68892dda52e4832eb7e6a2a6dfde6f16