### PR TITLE
Add websocket endpoint for admins list

### DIFF
--- a/custom_components/tally_list/__init__.py
+++ b/custom_components/tally_list/__init__.py
@@ -7,6 +7,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.exceptions import Unauthorized
 
+from .websocket import async_register as async_register_ws
+
 from .const import (
     DOMAIN,
     SERVICE_ADD_DRINK,
@@ -135,6 +137,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         SERVICE_RESET_COUNTERS,
         reset_counters_service,
     )
+
+    await async_register_ws(hass)
 
     return True
 

--- a/custom_components/tally_list/websocket.py
+++ b/custom_components/tally_list/websocket.py
@@ -1,0 +1,31 @@
+"""WebSocket commands for Tally List."""
+
+from __future__ import annotations
+
+from homeassistant.core import HomeAssistant
+from homeassistant.components import websocket_api
+from homeassistant.exceptions import Unauthorized
+import voluptuous as vol
+
+from .const import DOMAIN
+
+
+@websocket_api.websocket_command({vol.Required("type"): f"{DOMAIN}/get_admins"})
+@websocket_api.async_response
+async def websocket_get_admins(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict,
+) -> None:
+    """Return a list of admin user names."""
+    if connection.user is None:
+        raise Unauthorized
+
+    users = await hass.auth.async_get_users()
+    admins = [user.name for user in users if user.is_admin]
+    connection.send_result(msg["id"], {"admins": admins})
+
+
+async def async_register(hass: HomeAssistant) -> None:
+    """Register Tally List WebSocket commands."""
+    websocket_api.async_register_command(hass, websocket_get_admins)


### PR DESCRIPTION
## Summary
- expose new websocket command `tally_list/get_admins`
- register websocket command during integration setup
- fix registration to use `websocket_api.async_register_command`

## Testing
- `ruff check .`
- `pytest -q` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_688938b97ba4832ea657423ba6424efb