### PR TITLE
Fix get_admins WebSocket to use override list

### DIFF
--- a/custom_components/tally_list/websocket.py
+++ b/custom_components/tally_list/websocket.py
@@ -7,7 +7,7 @@ from homeassistant.components import websocket_api
 from homeassistant.exceptions import Unauthorized
 import voluptuous as vol
 
-from .const import DOMAIN
+from .const import DOMAIN, CONF_OVERRIDE_USERS
 
 
 @websocket_api.websocket_command({vol.Required("type"): f"{DOMAIN}/get_admins"})
@@ -21,8 +21,7 @@ async def websocket_get_admins(
     if connection.user is None:
         raise Unauthorized
 
-    users = await hass.auth.async_get_users()
-    admins = [user.name for user in users if user.is_admin]
+    admins = hass.data.get(DOMAIN, {}).get(CONF_OVERRIDE_USERS, [])
     connection.send_result(msg["id"], {"admins": admins})
 
 


### PR DESCRIPTION
## Summary
- fix `tally_list/get_admins` WebSocket to return override users rather than Home Assistant admins

## Testing
- `python -m py_compile custom_components/tally_list/websocket.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bbbd7c528832ea07ad6d80ccb019c