### PR TITLE
Restrict reset button usage to admins

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ The integration allows you to manage drink tallies for multiple persons from Hom
 
 - Persons with user accounts are added automatically. Drinks are added only once with a name and price and are available for every person.
 - Sensor entities for each drink's count, each drink's price, a free amount sensor, and a sensor showing the total amount a person has to pay.
-- Button entity to reset all counters for a person.
+- Button entity to reset all counters for a person. Only users with
+  override permissions ("Tally Admins") can press it.
 - Service `tally_list.add_drink` to add a drink for a person.
 - Service `tally_list.remove_drink` to remove a drink for a person.
 - Service `tally_list.adjust_count` to set a drink count to a specific value.
@@ -26,7 +27,7 @@ The integration allows you to manage drink tallies for multiple persons from Hom
 
 ## Usage
 
-When the integration is first set up, all persons with a user account are added and you will be asked to enter the available drinks. All further persons will automatically use this list. Drinks can later be managed from the integration options where you can add, remove or edit their prices. Call the service `tally_list.add_drink` with parameters `user` and `drink` to increment the counter. Use `tally_list.adjust_count` with `count` to set an exact value. To decrement by one call `tally_list.remove_drink` with `user` and `drink`. Use the reset button entity to reset all counters. The reset button entity ID follows `button.<person>_reset_tally`, so you can match all reset buttons with `button.*_reset_tally`.
+When the integration is first set up, all persons with a user account are added and you will be asked to enter the available drinks. All further persons will automatically use this list. Drinks can later be managed from the integration options where you can add, remove or edit their prices. Call the service `tally_list.add_drink` with parameters `user` and `drink` to increment the counter. Use `tally_list.adjust_count` with `count` to set an exact value. To decrement by one call `tally_list.remove_drink` with `user` and `drink`. Only Tally Admins can use the reset button entity to reset all counters. The reset button entity ID follows `button.<person>_reset_tally`, so you can match all reset buttons with `button.*_reset_tally`.
 
 ## Price List and Sensors
 

--- a/custom_components/tally_list/button.py
+++ b/custom_components/tally_list/button.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 from homeassistant.components.button import ButtonEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import Unauthorized
 from homeassistant.util import slugify
 
 from .const import (
     DOMAIN,
     SERVICE_RESET_COUNTERS,
     CONF_USER,
+    CONF_OVERRIDE_USERS,
     PRICE_LIST_USER,
 )
 
@@ -32,6 +34,22 @@ class ResetButton(ButtonEntity):
         self.entity_id = f"button.{slugify(user)}_reset_tally"
 
     async def async_press(self) -> None:
+        user_id = self._context.user_id if self._context else None
+        if user_id is not None:
+            hass_user = await self._hass.auth.async_get_user(user_id)
+            if hass_user is not None:
+                override_users = self._hass.data.get(DOMAIN, {}).get(
+                    CONF_OVERRIDE_USERS,
+                    [],
+                )
+                person_name = None
+                for state in self._hass.states.async_all("person"):
+                    if state.attributes.get("user_id") == hass_user.id:
+                        person_name = state.name
+                        break
+                if person_name not in override_users:
+                    raise Unauthorized
+
         await self._hass.services.async_call(
             DOMAIN,
             SERVICE_RESET_COUNTERS,


### PR DESCRIPTION
## Summary
- restrict reset button permission to Tally admins
- document new limitation in the README

## Testing
- `flake8 custom_components/tally_list/button.py`

------
https://chatgpt.com/codex/tasks/task_e_688bda619668832e9b97a4dc6deb3bd8