### PR TITLE
Ensure price list sensors show two decimals

### DIFF
--- a/custom_components/tally_list/sensor.py
+++ b/custom_components/tally_list/sensor.py
@@ -102,6 +102,7 @@ class DrinkPriceSensor(SensorEntity):
         self._attr_native_unit_of_measurement = hass.data.get(DOMAIN, {}).get(
             CONF_CURRENCY, "€"
         )
+        self._attr_suggested_display_precision = 2
 
     async def async_added_to_hass(self) -> None:
         await self.async_update_state()
@@ -115,7 +116,7 @@ class DrinkPriceSensor(SensorEntity):
     @property
     def native_value(self):
         drinks = self._hass.data.get(DOMAIN, {}).get("drinks", {})
-        return drinks.get(self._drink, self._price)
+        return round(drinks.get(self._drink, self._price), 2)
 
 
 class FreeAmountSensor(SensorEntity):
@@ -128,6 +129,7 @@ class FreeAmountSensor(SensorEntity):
         self._attr_native_unit_of_measurement = hass.data.get(DOMAIN, {}).get(
             CONF_CURRENCY, "€"
         )
+        self._attr_suggested_display_precision = 2
 
     async def async_added_to_hass(self) -> None:
         await self.async_update_state()
@@ -140,7 +142,7 @@ class FreeAmountSensor(SensorEntity):
 
     @property
     def native_value(self):
-        return self._hass.data.get(DOMAIN, {}).get("free_amount", 0.0)
+        return round(self._hass.data.get(DOMAIN, {}).get("free_amount", 0.0), 2)
 
 
 class TotalAmountSensor(RestoreEntity, SensorEntity):


### PR DESCRIPTION
## Summary
- Ensure price list sensors display two decimal digits for all values

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e4452d5f4832e81dccaff1fab3a66