### PR TITLE
Organize options flow into user and drink menus

### DIFF
--- a/custom_components/tally_list/config_flow.py
+++ b/custom_components/tally_list/config_flow.py
@@ -237,19 +237,40 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
         return self.async_show_menu(
             step_id="menu",
             menu_options=[
-                "add",
-                "remove",
-                "edit",
-                "free_amount",
-                "currency",
-                "exclude",
-                "include",
-                "authorize",
-                "unauthorize",
+                "user",
+                "drinks",
                 "cleanup",
                 "finish",
             ],
         )
+
+    async def async_step_user(self, user_input=None):
+        return self.async_show_menu(
+            step_id="user",
+            menu_options=[
+                "free_amount",
+                "exclude",
+                "include",
+                "authorize",
+                "unauthorize",
+                "back",
+            ],
+        )
+
+    async def async_step_drinks(self, user_input=None):
+        return self.async_show_menu(
+            step_id="drinks",
+            menu_options=[
+                "add",
+                "remove",
+                "edit",
+                "currency",
+                "back",
+            ],
+        )
+
+    async def async_step_back(self, user_input=None):
+        return await self.async_step_menu()
 
     async def async_step_add(self, user_input=None):
         return await self.async_step_add_drink(user_input)

--- a/custom_components/tally_list/translations/de.json
+++ b/custom_components/tally_list/translations/de.json
@@ -34,17 +34,31 @@
         "menu": {
           "title": "Strichliste verwalten",
           "menu_options": {
+            "user": "Nutzereinstellungen",
+            "drinks": "Getränkeeinstellungen",
+            "cleanup": "Nicht mehr genutzte Sensoren entfernen",
+            "finish": "Fertig"
+          }
+        },
+        "user": {
+          "title": "Nutzereinstellungen",
+          "menu_options": {
+            "free_amount": "Freibetrag setzen",
+            "exclude": "Nutzer ausschließen",
+            "include": "Ausschluss aufheben",
+            "authorize": "Nutzer berechtigen",
+            "unauthorize": "Berechtigung entziehen",
+            "back": "Zurück"
+          }
+        },
+        "drinks": {
+          "title": "Getränkeeinstellungen",
+          "menu_options": {
             "add": "Hinzufügen",
             "remove": "Entfernen",
             "edit": "Bearbeiten",
-            "free_amount": "Freibetrag",
             "currency": "Währung setzen",
-            "exclude": "Ausschließen",
-            "include": "Einschließen",
-            "authorize": "Berechtigen",
-            "unauthorize": "Entziehen",
-            "cleanup": "Nicht mehr genutzte Sensoren entfernen",
-            "finish": "Fertig"
+            "back": "Zurück"
           }
         },
         "add_drink": {
@@ -120,6 +134,8 @@
       },
       "enum": {
         "action": {
+          "user": "Nutzereinstellungen",
+          "drinks": "Getränkeeinstellungen",
           "add": "Hinzufügen",
           "remove": "Entfernen",
           "edit": "Bearbeiten",
@@ -130,7 +146,8 @@
           "authorize": "Berechtigen",
           "unauthorize": "Entziehen",
           "cleanup": "Nicht mehr genutzte Sensoren entfernen",
-          "finish": "Fertig"
+          "finish": "Fertig",
+          "back": "Zurück"
         }
       }
     }

--- a/custom_components/tally_list/translations/en.json
+++ b/custom_components/tally_list/translations/en.json
@@ -32,19 +32,33 @@
   "options": {
     "step": {
         "menu": {
-          "title": "Manage Drinks",
+          "title": "Tally List Options",
           "menu_options": {
-            "add": "Add drink",
-            "remove": "Remove drink",
-            "edit": "Edit price",
+            "user": "User settings",
+            "drinks": "Drink settings",
+            "cleanup": "Remove unused sensors",
+            "finish": "Done"
+          }
+        },
+        "user": {
+          "title": "User settings",
+          "menu_options": {
             "free_amount": "Set free amount",
-            "currency": "Set currency",
             "exclude": "Exclude user",
             "include": "Include user",
             "authorize": "Authorize user",
             "unauthorize": "Unauthorize user",
-            "cleanup": "Remove unused sensors",
-            "finish": "Done"
+            "back": "Back"
+          }
+        },
+        "drinks": {
+          "title": "Drink settings",
+          "menu_options": {
+            "add": "Add drink",
+            "remove": "Remove drink",
+            "edit": "Edit price",
+            "currency": "Set currency",
+            "back": "Back"
           }
         },
         "add_drink": {
@@ -120,6 +134,8 @@
       },
       "enum": {
         "action": {
+          "user": "User settings",
+          "drinks": "Drink settings",
           "add": "Add drink",
           "remove": "Remove drink",
           "edit": "Edit price",
@@ -130,7 +146,8 @@
           "authorize": "Authorize user",
           "unauthorize": "Unauthorize user",
           "cleanup": "Remove unused sensors",
-          "finish": "Done"
+          "finish": "Done",
+          "back": "Back"
         }
       }
   }


### PR DESCRIPTION
## Summary
- split options flow into user and drink submenus for clearer navigation
- add translations for new menu structure in English and German

## Testing
- `pre-commit run --files custom_components/tally_list/config_flow.py custom_components/tally_list/translations/en.json custom_components/tally_list/translations/de.json` *(fails: command not found)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f57a0f634832e9f55338e5431ab41