### PR TITLE
Rename user actions to person/admin rights

### DIFF
--- a/custom_components/tally_list/translations/de.json
+++ b/custom_components/tally_list/translations/de.json
@@ -44,10 +44,10 @@
           "title": "Nutzereinstellungen",
           "menu_options": {
             "free_amount": "Freibetrag setzen",
-            "exclude": "Nutzer ausschließen",
-            "include": "Ausschluss aufheben",
-            "authorize": "Nutzer berechtigen",
-            "unauthorize": "Berechtigung entziehen",
+            "exclude": "Person ausschließen",
+            "include": "Person einschließen",
+            "authorize": "Adminrechte vergeben",
+            "unauthorize": "Adminrechte entziehen",
             "back": "Zurück"
           }
         },
@@ -97,30 +97,30 @@
           }
         },
         "add_excluded_user": {
-          "title": "Nutzer ausschließen",
+          "title": "Person ausschließen",
           "data": {
-            "user": "Nutzer",
+            "user": "Person",
             "add_more": "Weiteren ausschließen"
           }
         },
         "remove_excluded_user": {
-          "title": "Ausschluss aufheben",
+          "title": "Person einschließen",
           "data": {
-            "user": "Nutzer",
+            "user": "Person",
             "remove_more": "Weiteren einschließen"
           }
         },
         "add_override_user": {
-          "title": "Nutzer berechtigen",
+          "title": "Adminrechte vergeben",
           "data": {
-            "user": "Nutzer",
+            "user": "Person",
             "add_more": "Weiteren berechtigen"
           }
         },
         "remove_override_user": {
-          "title": "Berechtigung entziehen",
+          "title": "Adminrechte entziehen",
           "data": {
-            "user": "Nutzer",
+            "user": "Person",
             "remove_more": "Weiteren entziehen"
           }
         },
@@ -141,10 +141,10 @@
           "edit": "Bearbeiten",
           "free_amount": "Freibetrag",
           "currency": "Währung setzen",
-          "exclude": "Ausschließen",
-          "include": "Einschließen",
-          "authorize": "Berechtigen",
-          "unauthorize": "Entziehen",
+          "exclude": "Person ausschließen",
+          "include": "Person einschließen",
+          "authorize": "Adminrechte vergeben",
+          "unauthorize": "Adminrechte entziehen",
           "cleanup": "Nicht mehr genutzte Sensoren entfernen",
           "finish": "Fertig",
           "back": "Zurück"

--- a/custom_components/tally_list/translations/en.json
+++ b/custom_components/tally_list/translations/en.json
@@ -44,10 +44,10 @@
           "title": "User settings",
           "menu_options": {
             "free_amount": "Set free amount",
-            "exclude": "Exclude user",
-            "include": "Include user",
-            "authorize": "Authorize user",
-            "unauthorize": "Unauthorize user",
+            "exclude": "Exclude person",
+            "include": "Include person",
+            "authorize": "Grant admin rights",
+            "unauthorize": "Revoke admin rights",
             "back": "Back"
           }
         },
@@ -97,30 +97,30 @@
           }
         },
         "add_excluded_user": {
-          "title": "Exclude User",
+          "title": "Exclude Person",
           "data": {
-            "user": "User",
+            "user": "Person",
             "add_more": "Exclude another"
           }
         },
         "remove_excluded_user": {
-          "title": "Include User",
+          "title": "Include Person",
           "data": {
-            "user": "User",
+            "user": "Person",
             "remove_more": "Include another"
           }
         },
         "add_override_user": {
-          "title": "Authorize User",
+          "title": "Grant Admin Rights",
           "data": {
-            "user": "User",
+            "user": "Person",
             "add_more": "Authorize another"
           }
         },
         "remove_override_user": {
-          "title": "Unauthorize User",
+          "title": "Revoke Admin Rights",
           "data": {
-            "user": "User",
+            "user": "Person",
             "remove_more": "Unauthorize another"
           }
         },
@@ -141,10 +141,10 @@
           "edit": "Edit price",
           "free_amount": "Set free amount",
           "currency": "Set currency",
-          "exclude": "Exclude user",
-          "include": "Include user",
-          "authorize": "Authorize user",
-          "unauthorize": "Unauthorize user",
+          "exclude": "Exclude person",
+          "include": "Include person",
+          "authorize": "Grant admin rights",
+          "unauthorize": "Revoke admin rights",
           "cleanup": "Remove unused sensors",
           "finish": "Done",
           "back": "Back"


### PR DESCRIPTION
## Summary
- rename user management labels to use "Person" and admin rights in German
- rename user management labels to match in English

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f5c5736e8832eb05fcf170df4917f