### PR TITLE
chore: bump version to 1.11.0

### DIFF
--- a/custom_components/tally_list/manifest.json
+++ b/custom_components/tally_list/manifest.json
@@ -2,7 +2,7 @@
   "domain": "tally_list",
   "name": "Tally List",
   "documentation": "https://github.com/Spider19996/ha-tally-list",
-  "version": "1.0.0",
+  "version": "1.11.0",
   "requirements": [],
   "config_flow": true,
   "codeowners": []


### PR DESCRIPTION
## Summary
- bump integration version to 1.11.0

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f5ecd9008832e974e982c7799069f