### PR TITLE
Sort CSV export alphabetically

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The integration allows you to manage drink tallies for multiple persons from Hom
 - Service `tally_list.add_drink` to add a drink for a person.
 - Service `tally_list.remove_drink` to remove a drink for a person.
 - Service `tally_list.adjust_count` to set a drink count to a specific value.
-- Service `tally_list.export_csv` to export all amount_due sensors to a CSV file.
+- Service `tally_list.export_csv` to export all amount_due sensors to a CSV file, sorted alphabetically by name.
 - Counters cannot go below zero when removing drinks.
 - Exclude persons from automatic import via the integration options.
 - Grant override permissions to selected users so they can tally drinks for
@@ -30,7 +30,7 @@ The integration allows you to manage drink tallies for multiple persons from Hom
 ## Usage
 
 When the integration is first set up, all persons with a user account are added and you will be asked to enter the available drinks. All further persons will automatically use this list. Drinks can later be managed from the integration options where you can add, remove or edit their prices. Call the service `tally_list.add_drink` with parameters `user` and `drink` to increment the counter. Use `tally_list.adjust_count` with `count` to set an exact value. To decrement by one call `tally_list.remove_drink` with `user` and `drink`. Only Tally Admins can use the reset button entity to reset all counters. The reset button entity ID follows `button.<person>_reset_tally`, so you can match all reset buttons with `button.*_reset_tally`.
-Call `tally_list.export_csv` to create a CSV snapshot of all `_amount_due` sensors. The file is stored as `amount_due_YYYY-MM-DD_HH-MM.csv` inside `/config/backup/tally_list/`.
+Call `tally_list.export_csv` to create a CSV snapshot of all `_amount_due` sensors sorted alphabetically by name. The file is stored as `amount_due_YYYY-MM-DD_HH-MM.csv` inside `/config/backup/tally_list/`.
 
 ## Price List and Sensors
 

--- a/custom_components/tally_list/__init__.py
+++ b/custom_components/tally_list/__init__.py
@@ -125,11 +125,14 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                     await sensor.async_update_state()
 
     async def export_csv_service(call):
-        sensors = [
-            state
-            for state in hass.states.async_all("sensor")
-            if state.entity_id.endswith("_amount_due")
-        ]
+        sensors = sorted(
+            [
+                state
+                for state in hass.states.async_all("sensor")
+                if state.entity_id.endswith("_amount_due")
+            ],
+            key=lambda state: state.name.casefold(),
+        )
         currency = hass.data.get(DOMAIN, {}).get(CONF_CURRENCY, "€")
         timestamp = dt_now().strftime("%Y-%m-%d_%H-%M")
         directory = hass.config.path("backup", "tally_list")
@@ -137,19 +140,18 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
         def _write() -> None:
             os.makedirs(directory, exist_ok=True)
-            with open(file_path, "w", newline="", encoding="utf-8") as csvfile:
-                writer = csv.writer(csvfile)
-                writer.writerow(["Name", f"Betrag ({currency})"])
-                for state in sensors:
-                    try:
-                        amount = float(state.state)
-                    except (ValueError, TypeError):
-                        amount = 0.0
-                        
-                    writer.writerow([state.name, f"{amount:.2f}"])
+        with open(file_path, "w", newline="", encoding="utf-8") as csvfile:
+            writer = csv.writer(csvfile)
+            writer.writerow(["Name", f"Betrag ({currency})"])
+            for state in sensors:
+                try:
+                    amount = float(state.state)
+                except (ValueError, TypeError):
+                    amount = 0.0
+
+                writer.writerow([state.name, f"{amount:.2f}"])
 
         await hass.async_add_executor_job(_write)
-
 
     hass.services.async_register(
         DOMAIN,


### PR DESCRIPTION
## Summary
- ensure CSV export service sorts entries alphabetically by name
- document alphabetical sorting for CSV export

## Testing
- `pytest`
- `flake8 custom_components/tally_list/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_6890fa7614a4832eb446be1f6c2b4dc9