### PR TITLE
feat: add flexible csv export schedules

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The integration allows you to manage drink tallies for multiple persons from Hom
 - Service `tally_list.add_drink` to add a drink for a person.
 - Service `tally_list.remove_drink` to remove a drink for a person.
 - Service `tally_list.adjust_count` to set a drink count to a specific value.
-- Service `tally_list.export_csv` to export all amount_due sensors to a CSV file, sorted alphabetically by name.
+- Service `tally_list.export_csv` to export all amount_due sensors to CSV files (daily, weekly, monthly or manual), sorted alphabetically by name.
 - Counters cannot go below zero when removing drinks.
 - Exclude persons from automatic import via the integration options.
 - Grant override permissions to selected users so they can tally drinks for
@@ -30,7 +30,14 @@ The integration allows you to manage drink tallies for multiple persons from Hom
 ## Usage
 
 When the integration is first set up, all persons with a user account are added and you will be asked to enter the available drinks. All further persons will automatically use this list. Drinks can later be managed from the integration options where you can add, remove or edit their prices. Call the service `tally_list.add_drink` with parameters `user` and `drink` to increment the counter. Use `tally_list.adjust_count` with `count` to set an exact value. To decrement by one call `tally_list.remove_drink` with `user` and `drink`. Only Tally Admins can use the reset button entity to reset all counters. The reset button entity ID follows `button.<person>_reset_tally`, so you can match all reset buttons with `button.*_reset_tally`.
-Call `tally_list.export_csv` to create a CSV snapshot of all `_amount_due` sensors sorted alphabetically by name. The file is stored as `amount_due_YYYY-MM-DD_HH-MM.csv` inside `/config/backup/tally_list/`.
+Call `tally_list.export_csv` to create CSV snapshots of all `_amount_due` sensors sorted alphabetically by name. Depending on the parameters, the service writes files to `/config/backup/tally_list/` in the subfolders `daily`, `weekly`, `monthly` or `manual`:
+
+- `daily/amount_due_YYYY-MM-DD_HH-MM.csv`
+- `weekly/amount_due_week_YYYY-WW.csv`
+- `monthly/amount_due_YYYY-MM.csv`
+- `manual/amount_due_manual_YYYY-MM-DD_HH-MM.csv`
+
+All sections are disabled by default and can be toggled from the service call UI via the `daily_enable`, `weekly_enable`, `monthly_enable`, or `manual_enable` options. Optional `*_keep_days` parameters control how long files are retained, and the monthly export supports a `monthly_interval` to only create files every n-th month.
 
 ## Price List and Sensors
 

--- a/custom_components/tally_list/__init__.py
+++ b/custom_components/tally_list/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import csv
 import os
+from datetime import datetime, timedelta
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -134,24 +135,107 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             key=lambda state: state.name.casefold(),
         )
         currency = hass.data.get(DOMAIN, {}).get(CONF_CURRENCY, "€")
-        timestamp = dt_now().strftime("%Y-%m-%d_%H-%M")
-        directory = hass.config.path("backup", "tally_list")
-        file_path = os.path.join(directory, f"amount_due_{timestamp}.csv")
+        now = dt_now()
+        base_dir = hass.config.path("backup", "tally_list")
 
-        def _write() -> None:
-            os.makedirs(directory, exist_ok=True)
-        with open(file_path, "w", newline="", encoding="utf-8") as csvfile:
-            writer = csv.writer(csvfile)
-            writer.writerow(["Name", f"Betrag ({currency})"])
-            for state in sensors:
-                try:
-                    amount = float(state.state)
-                except (ValueError, TypeError):
-                    amount = 0.0
+        def _write_csv(path: str) -> None:
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            with open(path, "w", newline="", encoding="utf-8") as csvfile:
+                writer = csv.writer(csvfile)
+                writer.writerow(["Name", f"Betrag ({currency})"])
+                for state in sensors:
+                    try:
+                        amount = float(state.state)
+                    except (ValueError, TypeError):
+                        amount = 0.0
+                    writer.writerow([state.name, f"{amount:.2f}"])
 
-                writer.writerow([state.name, f"{amount:.2f}"])
+        def _cleanup(path: str, keep: int | None) -> None:
+            if keep is None or keep <= 0:
+                return
+            cutoff = now - timedelta(days=keep)
+            if not os.path.isdir(path):
+                return
+            for filename in os.listdir(path):
+                file_path = os.path.join(path, filename)
+                if not os.path.isfile(file_path):
+                    continue
+                mtime = datetime.fromtimestamp(
+                    os.path.getmtime(file_path), tz=now.tzinfo
+                )
+                if mtime < cutoff:
+                    os.remove(file_path)
 
-        await hass.async_add_executor_job(_write)
+        daily_cfg = {
+            "enable": call.data.get("daily_enable", False),
+            "keep_days": call.data.get("daily_keep_days", 7),
+        }
+        if "daily" in call.data:
+            daily_cfg.update(call.data["daily"])
+        weekly_cfg = {
+            "enable": call.data.get("weekly_enable", False),
+            "keep_days": call.data.get("weekly_keep_days", 30),
+        }
+        if "weekly" in call.data:
+            weekly_cfg.update(call.data["weekly"])
+        monthly_cfg = {
+            "enable": call.data.get("monthly_enable", False),
+            "interval": call.data.get("monthly_interval", 3),
+            "keep_days": call.data.get("monthly_keep_days", 365),
+        }
+        if "monthly" in call.data:
+            monthly_cfg.update(call.data["monthly"])
+        manual_cfg = {
+            "enable": call.data.get("manual_enable", False),
+            "keep_days": call.data.get("manual_keep_days", 180),
+        }
+        if "manual" in call.data:
+            manual_cfg.update(call.data["manual"])
+
+        if daily_cfg.get("enable"):
+            file_path = os.path.join(
+                base_dir, "daily", f"amount_due_{now.strftime('%Y-%m-%d_%H-%M')}.csv"
+            )
+            await hass.async_add_executor_job(_write_csv, file_path)
+        await hass.async_add_executor_job(
+            _cleanup, os.path.join(base_dir, "daily"), daily_cfg.get("keep_days")
+        )
+
+        if weekly_cfg.get("enable"):
+            iso_year, iso_week, _ = now.isocalendar()
+            weekly_file = os.path.join(
+                base_dir,
+                "weekly",
+                f"amount_due_week_{iso_year}-{iso_week:02d}.csv",
+            )
+            if not os.path.exists(weekly_file):
+                await hass.async_add_executor_job(_write_csv, weekly_file)
+        await hass.async_add_executor_job(
+            _cleanup, os.path.join(base_dir, "weekly"), weekly_cfg.get("keep_days")
+        )
+
+        if monthly_cfg.get("enable"):
+            interval = monthly_cfg.get("interval", 1) or 1
+            if now.month % interval == 0:
+                monthly_file = os.path.join(
+                    base_dir, "monthly", f"amount_due_{now.strftime('%Y-%m')}.csv"
+                )
+                if not os.path.exists(monthly_file):
+                    await hass.async_add_executor_job(_write_csv, monthly_file)
+        await hass.async_add_executor_job(
+            _cleanup, os.path.join(base_dir, "monthly"), monthly_cfg.get("keep_days")
+        )
+
+        if manual_cfg.get("enable"):
+            manual_file = os.path.join(
+                base_dir,
+                "manual",
+                f"amount_due_manual_{now.strftime('%Y-%m-%d_%H-%M')}.csv",
+            )
+            await hass.async_add_executor_job(_write_csv, manual_file)
+        await hass.async_add_executor_job(
+            _cleanup, os.path.join(base_dir, "manual"), manual_cfg.get("keep_days")
+        )
 
     hass.services.async_register(
         DOMAIN,

--- a/custom_components/tally_list/services.yaml
+++ b/custom_components/tally_list/services.yaml
@@ -41,4 +41,69 @@ reset_counters:
       required: false
 export_csv:
   name: Export CSV
-  description: Export all amount_due sensors to a CSV file
+  description: Export all amount_due sensors to CSV files
+  fields:
+    daily_enable:
+      description: Enable daily export
+      required: false
+      default: false
+      selector:
+        boolean:
+    daily_keep_days:
+      description: Days to keep daily exports
+      required: false
+      example: 7
+      selector:
+        number:
+          min: 1
+          step: 1
+    weekly_enable:
+      description: Enable weekly export
+      required: false
+      default: false
+      selector:
+        boolean:
+    weekly_keep_days:
+      description: Days to keep weekly exports
+      required: false
+      example: 30
+      selector:
+        number:
+          min: 1
+          step: 1
+    monthly_enable:
+      description: Enable monthly export
+      required: false
+      default: false
+      selector:
+        boolean:
+    monthly_interval:
+      description: Only export every n-th month
+      required: false
+      example: 3
+      selector:
+        number:
+          min: 1
+          step: 1
+    monthly_keep_days:
+      description: Days to keep monthly exports
+      required: false
+      example: 365
+      selector:
+        number:
+          min: 1
+          step: 1
+    manual_enable:
+      description: Enable manual export
+      required: false
+      default: false
+      selector:
+        boolean:
+    manual_keep_days:
+      description: Days to keep manual exports
+      required: false
+      example: 180
+      selector:
+        number:
+          min: 1
+          step: 1


### PR DESCRIPTION
## Summary
- expose per-schedule CSV export options with UI-friendly selectors and defaults disabled
- document that exports must be enabled explicitly and describe retention/interval options

## Testing
- `python -m py_compile custom_components/tally_list/__init__.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890fd8b3cd8832e9954efc20af4a745