### PR TITLE
Remove 'Amount Due' suffix from CSV exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Call `tally_list.export_csv` to create CSV snapshots of all `_amount_due` sensor
 - `monthly/amount_due_YYYY-MM.csv`
 - `manual/amount_due_manual_YYYY-MM-DD_HH-MM.csv`
 
+The exported files list each person without the trailing `Amount Due` text.
+
 All sections are disabled by default and can be toggled from the service call UI via the `daily_enable`, `weekly_enable`, `monthly_enable`, or `manual_enable` options. Optional `*_keep_days` parameters control how long files are retained, and the monthly export supports a `monthly_interval` to only create files every n-th month.
 
 ## Price List and Sensors

--- a/custom_components/tally_list/__init__.py
+++ b/custom_components/tally_list/__init__.py
@@ -148,7 +148,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                         amount = float(state.state)
                     except (ValueError, TypeError):
                         amount = 0.0
-                    writer.writerow([state.name, f"{amount:.2f}"])
+                    name = state.name.replace(" Amount Due", "")
+                    writer.writerow([name, f"{amount:.2f}"])
 
         def _cleanup(path: str, keep: int | None) -> None:
             if keep is None or keep <= 0:


### PR DESCRIPTION
## Summary
- Strip "Amount Due" from person names in exported CSV files
- Document that CSV exports no longer include the suffix

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68910348b544832eb635b06ee6781793