### PR TITLE
Include schedule names in backup filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ The integration allows you to manage drink tallies for multiple persons from Hom
 When the integration is first set up, all persons with a user account are added and you will be asked to enter the available drinks. All further persons will automatically use this list. Drinks can later be managed from the integration options where you can add, remove or edit their prices. Call the service `tally_list.add_drink` with parameters `user` and `drink` to increment the counter. Use `tally_list.adjust_count` with `count` to set an exact value. To decrement by one call `tally_list.remove_drink` with `user` and `drink`. Only Tally Admins can use the reset button entity to reset all counters. The reset button entity ID follows `button.<person>_reset_tally`, so you can match all reset buttons with `button.*_reset_tally`.
 Call `tally_list.export_csv` to create CSV snapshots of all `_amount_due` sensors sorted alphabetically by name. Depending on the parameters, the service writes files to `/config/backup/tally_list/` in the subfolders `daily`, `weekly`, `monthly` or `manual`:
 
-- `daily/amount_due_YYYY-MM-DD_HH-MM.csv`
-- `weekly/amount_due_week_YYYY-WW.csv`
-- `monthly/amount_due_YYYY-MM.csv`
+- `daily/amount_due_daily_YYYY-MM-DD_HH-MM.csv`
+- `weekly/amount_due_weekly_YYYY-WW.csv`
+- `monthly/amount_due_monthly_YYYY-MM.csv`
 - `manual/amount_due_manual_YYYY-MM-DD_HH-MM.csv`
 
 All sections are disabled by default and can be toggled from the service call UI via the `daily_enable`, `weekly_enable`, `monthly_enable`, or `manual_enable` options. Optional `*_keep_days` parameters control how long files are retained, and the monthly export supports a `monthly_interval` to only create files every n-th month.

--- a/custom_components/tally_list/__init__.py
+++ b/custom_components/tally_list/__init__.py
@@ -194,7 +194,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
         if daily_cfg.get("enable"):
             file_path = os.path.join(
-                base_dir, "daily", f"amount_due_{now.strftime('%Y-%m-%d_%H-%M')}.csv"
+                base_dir,
+                "daily",
+                f"amount_due_daily_{now.strftime('%Y-%m-%d_%H-%M')}.csv",
             )
             await hass.async_add_executor_job(_write_csv, file_path)
         await hass.async_add_executor_job(
@@ -206,7 +208,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             weekly_file = os.path.join(
                 base_dir,
                 "weekly",
-                f"amount_due_week_{iso_year}-{iso_week:02d}.csv",
+                f"amount_due_weekly_{iso_year}-{iso_week:02d}.csv",
             )
             if not os.path.exists(weekly_file):
                 await hass.async_add_executor_job(_write_csv, weekly_file)
@@ -218,7 +220,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             interval = monthly_cfg.get("interval", 1) or 1
             if now.month % interval == 0:
                 monthly_file = os.path.join(
-                    base_dir, "monthly", f"amount_due_{now.strftime('%Y-%m')}.csv"
+                    base_dir,
+                    "monthly",
+                    f"amount_due_monthly_{now.strftime('%Y-%m')}.csv",
                 )
                 if not os.path.exists(monthly_file):
                     await hass.async_add_executor_job(_write_csv, monthly_file)


### PR DESCRIPTION
## Summary
- include backup schedule in CSV export filenames for daily, weekly and monthly exports
- update README to document new naming convention

## Testing
- `python -m py_compile custom_components/tally_list/__init__.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689102f9f1ec832eb567cf0e2a0eafa6