### PR TITLE
Refactor export_csv service to use backup type configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Call `tally_list.export_csv` to create CSV snapshots of all `_amount_due` sensor
 - `monthly/amount_due_YYYY-MM.csv`
 - `manual/amount_due_manual_YYYY-MM-DD_HH-MM.csv`
 
-All sections are disabled by default and can be toggled from the service call UI via the `daily_enable`, `weekly_enable`, `monthly_enable`, or `manual_enable` options. Optional `*_keep_days` parameters control how long files are retained, and the monthly export supports a `monthly_interval` to only create files every n-th month.
+Select the desired type via the `backup` option and optionally set `keep_days` to control how long files are retained. Monthly exports also support an `interval` option to only create files every n-th month.
 
 ## Price List and Sensors
 

--- a/custom_components/tally_list/__init__.py
+++ b/custom_components/tally_list/__init__.py
@@ -166,42 +166,26 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                 if mtime < cutoff:
                     os.remove(file_path)
 
-        daily_cfg = {
-            "enable": call.data.get("daily_enable", False),
-            "keep_days": call.data.get("daily_keep_days", 7),
-        }
-        if "daily" in call.data:
-            daily_cfg.update(call.data["daily"])
-        weekly_cfg = {
-            "enable": call.data.get("weekly_enable", False),
-            "keep_days": call.data.get("weekly_keep_days", 30),
-        }
-        if "weekly" in call.data:
-            weekly_cfg.update(call.data["weekly"])
-        monthly_cfg = {
-            "enable": call.data.get("monthly_enable", False),
-            "interval": call.data.get("monthly_interval", 3),
-            "keep_days": call.data.get("monthly_keep_days", 365),
-        }
-        if "monthly" in call.data:
-            monthly_cfg.update(call.data["monthly"])
-        manual_cfg = {
-            "enable": call.data.get("manual_enable", False),
-            "keep_days": call.data.get("manual_keep_days", 180),
-        }
-        if "manual" in call.data:
-            manual_cfg.update(call.data["manual"])
+        backup_type = call.data.get("backup")
+        if backup_type not in {"daily", "weekly", "monthly", "manual"}:
+            return
 
-        if daily_cfg.get("enable"):
+        keep_days = call.data.get("keep_days")
+        interval = call.data.get("interval")
+
+        if backup_type == "daily":
+            keep_days = keep_days if keep_days is not None else 7
+            timestamp = now.strftime("%Y-%m-%d_%H-%M")
             file_path = os.path.join(
-                base_dir, "daily", f"amount_due_{now.strftime('%Y-%m-%d_%H-%M')}.csv"
+                base_dir, "daily", f"amount_due_{timestamp}.csv"
             )
             await hass.async_add_executor_job(_write_csv, file_path)
-        await hass.async_add_executor_job(
-            _cleanup, os.path.join(base_dir, "daily"), daily_cfg.get("keep_days")
-        )
+            await hass.async_add_executor_job(
+                _cleanup, os.path.join(base_dir, "daily"), keep_days
+            )
 
-        if weekly_cfg.get("enable"):
+        elif backup_type == "weekly":
+            keep_days = keep_days if keep_days is not None else 30
             iso_year, iso_week, _ = now.isocalendar()
             weekly_file = os.path.join(
                 base_dir,
@@ -210,32 +194,36 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             )
             if not os.path.exists(weekly_file):
                 await hass.async_add_executor_job(_write_csv, weekly_file)
-        await hass.async_add_executor_job(
-            _cleanup, os.path.join(base_dir, "weekly"), weekly_cfg.get("keep_days")
-        )
+            await hass.async_add_executor_job(
+                _cleanup, os.path.join(base_dir, "weekly"), keep_days
+            )
 
-        if monthly_cfg.get("enable"):
-            interval = monthly_cfg.get("interval", 1) or 1
+        elif backup_type == "monthly":
+            keep_days = keep_days if keep_days is not None else 365
+            interval = interval or 3
             if now.month % interval == 0:
+                month_str = now.strftime("%Y-%m")
                 monthly_file = os.path.join(
-                    base_dir, "monthly", f"amount_due_{now.strftime('%Y-%m')}.csv"
+                    base_dir, "monthly", f"amount_due_{month_str}.csv"
                 )
                 if not os.path.exists(monthly_file):
                     await hass.async_add_executor_job(_write_csv, monthly_file)
-        await hass.async_add_executor_job(
-            _cleanup, os.path.join(base_dir, "monthly"), monthly_cfg.get("keep_days")
-        )
+            await hass.async_add_executor_job(
+                _cleanup, os.path.join(base_dir, "monthly"), keep_days
+            )
 
-        if manual_cfg.get("enable"):
+        elif backup_type == "manual":
+            keep_days = keep_days if keep_days is not None else 180
+            timestamp = now.strftime("%Y-%m-%d_%H-%M")
             manual_file = os.path.join(
                 base_dir,
                 "manual",
-                f"amount_due_manual_{now.strftime('%Y-%m-%d_%H-%M')}.csv",
+                f"amount_due_manual_{timestamp}.csv",
             )
             await hass.async_add_executor_job(_write_csv, manual_file)
-        await hass.async_add_executor_job(
-            _cleanup, os.path.join(base_dir, "manual"), manual_cfg.get("keep_days")
-        )
+            await hass.async_add_executor_job(
+                _cleanup, os.path.join(base_dir, "manual"), keep_days
+            )
 
     hass.services.async_register(
         DOMAIN,

--- a/custom_components/tally_list/services.yaml
+++ b/custom_components/tally_list/services.yaml
@@ -43,66 +43,29 @@ export_csv:
   name: Export CSV
   description: Export all amount_due sensors to CSV files
   fields:
-    daily_enable:
-      description: Enable daily export
-      required: false
-      default: false
+    backup:
+      description: Type of backup to create
+      required: true
+      example: daily
       selector:
-        boolean:
-    daily_keep_days:
-      description: Days to keep daily exports
-      required: false
-      example: 7
-      selector:
-        number:
-          min: 1
-          step: 1
-    weekly_enable:
-      description: Enable weekly export
-      required: false
-      default: false
-      selector:
-        boolean:
-    weekly_keep_days:
-      description: Days to keep weekly exports
-      required: false
-      example: 30
-      selector:
-        number:
-          min: 1
-          step: 1
-    monthly_enable:
-      description: Enable monthly export
-      required: false
-      default: false
-      selector:
-        boolean:
-    monthly_interval:
-      description: Only export every n-th month
+        select:
+          options:
+            - daily
+            - weekly
+            - monthly
+            - manual
+    interval:
+      description: Only for monthly backups, export every n-th month
       required: false
       example: 3
       selector:
         number:
           min: 1
           step: 1
-    monthly_keep_days:
-      description: Days to keep monthly exports
+    keep_days:
+      description: Days to keep exports (defaults: daily 7, weekly 30, monthly 365, manual 180)
       required: false
-      example: 365
-      selector:
-        number:
-          min: 1
-          step: 1
-    manual_enable:
-      description: Enable manual export
-      required: false
-      default: false
-      selector:
-        boolean:
-    manual_keep_days:
-      description: Days to keep manual exports
-      required: false
-      example: 180
+      example: 7
       selector:
         number:
           min: 1


### PR DESCRIPTION
## Summary
- simplify `tally_list.export_csv` service parameters
- document new service call

## Testing
- `pytest`
- `flake8 custom_components/tally_list/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_689103ff0ef8832ebd07409d4e4a4fa6