### PR TITLE
chore: bump version to 1.12.0 for backup service

### DIFF
--- a/custom_components/tally_list/manifest.json
+++ b/custom_components/tally_list/manifest.json
@@ -2,7 +2,7 @@
   "domain": "tally_list",
   "name": "Tally List",
   "documentation": "https://github.com/Spider19996/ha-tally-list",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "requirements": [],
   "config_flow": true,
   "codeowners": []


### PR DESCRIPTION
## Summary
- bump version to 1.12.0 for backup service

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689105e3aec8832e97a4a4b8e790bc54