### PR TITLE
Refactor export CSV service configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,11 @@ Call `tally_list.export_csv` to create CSV snapshots of all `_amount_due` sensor
 - `manual/amount_due_manual_YYYY-MM-DD_HH-MM.csv`
 
 The exported files list each person without the trailing `Amount Due` text.
+The service accepts the following parameters:
 
-All sections are disabled by default and can be toggled from the service call UI via the `daily_enable`, `weekly_enable`, `monthly_enable`, or `manual_enable` options. Optional `*_keep_days` parameters control how long files are retained, and the monthly export supports a `monthly_interval` to only create files every n-th month.
+- `backup`: Required. Choose `daily`, `weekly`, `monthly`, or `manual`.
+- `interval`: Optional. Create a backup only every n-th day, week, or month depending on the selected backup. Ignored for manual backups.
+- `keep`: Optional. For daily backups remove files older than this number of days. For weekly and monthly backups the value is interpreted as weeks or months. Manual backups keep only the latest number of files.
 
 ## Price List and Sensors
 

--- a/custom_components/tally_list/services.yaml
+++ b/custom_components/tally_list/services.yaml
@@ -43,66 +43,32 @@ export_csv:
   name: Export CSV
   description: Export all amount_due sensors to CSV files
   fields:
-    daily_enable:
-      description: Enable daily export
-      required: false
-      default: false
+    backup:
+      description: Type of backup to create
+      required: true
       selector:
-        boolean:
-    daily_keep_days:
-      description: Days to keep daily exports
+        select:
+          options:
+            - daily
+            - weekly
+            - monthly
+            - manual
+    interval:
+      description: >-
+        Create a backup every X days, weeks or months depending on the selected
+        backup. Ignored for manual backups.
+      required: false
+      example: 1
+      selector:
+        number:
+          min: 1
+          step: 1
+    keep:
+      description: >-
+        Delete backups older than X days, weeks or months depending on the
+        selected backup. For manual backups keep only the latest X files.
       required: false
       example: 7
-      selector:
-        number:
-          min: 1
-          step: 1
-    weekly_enable:
-      description: Enable weekly export
-      required: false
-      default: false
-      selector:
-        boolean:
-    weekly_keep_days:
-      description: Days to keep weekly exports
-      required: false
-      example: 30
-      selector:
-        number:
-          min: 1
-          step: 1
-    monthly_enable:
-      description: Enable monthly export
-      required: false
-      default: false
-      selector:
-        boolean:
-    monthly_interval:
-      description: Only export every n-th month
-      required: false
-      example: 3
-      selector:
-        number:
-          min: 1
-          step: 1
-    monthly_keep_days:
-      description: Days to keep monthly exports
-      required: false
-      example: 365
-      selector:
-        number:
-          min: 1
-          step: 1
-    manual_enable:
-      description: Enable manual export
-      required: false
-      default: false
-      selector:
-        boolean:
-    manual_keep_days:
-      description: Days to keep manual exports
-      required: false
-      example: 180
       selector:
         number:
           min: 1


### PR DESCRIPTION
## Summary
- simplify `tally_list.export_csv` service with `backup`, `interval`, and `keep` options
- remove individual enable flags and handle cleanup for days, weeks, months, or manual file count
- document new service parameters in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891075f94e4832e905353d4cbb61408