### PR TITLE
Add selectors for Tally List services

### DIFF
--- a/custom_components/tally_list/services.yaml
+++ b/custom_components/tally_list/services.yaml
@@ -5,9 +5,13 @@ add_drink:
     user:
       description: Person name
       example: Alice
+      selector:
+        text:
     drink:
       description: Drink name
       example: beer
+      selector:
+        text:
 remove_drink:
   name: Remove drink
   description: Decrement drink counter for a person
@@ -15,9 +19,13 @@ remove_drink:
     user:
       description: Person name
       example: Alice
+      selector:
+        text:
     drink:
       description: Drink name
       example: beer
+      selector:
+        text:
 adjust_count:
   name: Adjust count
   description: Set drink count for a person
@@ -25,12 +33,20 @@ adjust_count:
     user:
       description: Person name
       example: Alice
+      selector:
+        text:
     drink:
       description: Drink name
       example: beer
+      selector:
+        text:
     count:
       description: Desired drink count
       example: 3
+      selector:
+        number:
+          min: 0
+          step: 1
 reset_counters:
   name: Reset counters
   description: Reset counters for a person. If no user is specified, reset all.
@@ -39,6 +55,8 @@ reset_counters:
       description: Person name
       example: Alice
       required: false
+      selector:
+        text:
 export_csv:
   name: Export CSV
   description: Export all amount_due sensors to CSV files


### PR DESCRIPTION
## Summary
- add UI selectors for user, drink and count parameters of tally_list services

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689109f23e3c832ea932dcc101dd7a06