### PR TITLE
Add selectors for Tally List services

### DIFF
--- a/custom_components/tally_list/services.yaml
+++ b/custom_components/tally_list/services.yaml
@@ -5,9 +5,15 @@ add_drink:
     user:
       description: Person name
       example: Alice
+      required: true
+      selector:
+        text:
     drink:
       description: Drink name
       example: beer
+      required: true
+      selector:
+        text:
 remove_drink:
   name: Remove drink
   description: Decrement drink counter for a person
@@ -15,9 +21,15 @@ remove_drink:
     user:
       description: Person name
       example: Alice
+      required: true
+      selector:
+        text:
     drink:
       description: Drink name
       example: beer
+      required: true
+      selector:
+        text:
 adjust_count:
   name: Adjust count
   description: Set drink count for a person
@@ -25,12 +37,23 @@ adjust_count:
     user:
       description: Person name
       example: Alice
+      required: true
+      selector:
+        text:
     drink:
       description: Drink name
       example: beer
+      required: true
+      selector:
+        text:
     count:
       description: Desired drink count
       example: 3
+      required: true
+      selector:
+        number:
+          min: 0
+          step: 1
 reset_counters:
   name: Reset counters
   description: Reset counters for a person. If no user is specified, reset all.
@@ -39,6 +62,8 @@ reset_counters:
       description: Person name
       example: Alice
       required: false
+      selector:
+        text:
 export_csv:
   name: Export CSV
   description: Export all amount_due sensors to CSV files


### PR DESCRIPTION
## Summary
- add UI selectors for user, drink and count parameters of tally_list services
- mark tally_list service fields as required

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689109f23e3c832ea932dcc101dd7a06