### PR TITLE
Add bilingual service translations

### DIFF
--- a/custom_components/tally_list/translations/de.json
+++ b/custom_components/tally_list/translations/de.json
@@ -150,5 +150,81 @@
           "back": "Zurück"
         }
       }
+    },
+  "services": {
+    "add_drink": {
+      "name": "Getränk hinzufügen",
+      "description": "Erhöht den Getränkezähler für eine Person",
+      "fields": {
+        "user": {
+          "name": "Person",
+          "description": "Name der Person"
+        },
+        "drink": {
+          "name": "Getränk",
+          "description": "Name des Getränks"
+        }
+      }
+    },
+    "remove_drink": {
+      "name": "Getränk entfernen",
+      "description": "Verringert den Getränkezähler für eine Person",
+      "fields": {
+        "user": {
+          "name": "Person",
+          "description": "Name der Person"
+        },
+        "drink": {
+          "name": "Getränk",
+          "description": "Name des Getränks"
+        }
+      }
+    },
+    "adjust_count": {
+      "name": "Zähler anpassen",
+      "description": "Setzt den Getränkezähler für eine Person",
+      "fields": {
+        "user": {
+          "name": "Person",
+          "description": "Name der Person"
+        },
+        "drink": {
+          "name": "Getränk",
+          "description": "Name des Getränks"
+        },
+        "count": {
+          "name": "Anzahl",
+          "description": "Gewünschte Anzahl an Getränken"
+        }
+      }
+    },
+    "reset_counters": {
+      "name": "Zähler zurücksetzen",
+      "description": "Setzt die Zähler für eine Person zurück. Wenn keine Person angegeben ist, werden alle zurückgesetzt.",
+      "fields": {
+        "user": {
+          "name": "Person",
+          "description": "Name der Person"
+        }
+      }
+    },
+    "export_csv": {
+      "name": "CSV exportieren",
+      "description": "Exportiert alle amount_due Sensoren in CSV-Dateien",
+      "fields": {
+        "backup": {
+          "name": "Backup-Typ",
+          "description": "Art des zu erstellenden Backups"
+        },
+        "interval": {
+          "name": "Intervall",
+          "description": "Erstelle ein Backup alle X Tage, Wochen oder Monate abhängig vom gewählten Backup. Für manuelle Backups ignoriert."
+        },
+        "keep": {
+          "name": "Aufbewahren",
+          "description": "Lösche Backups älter als X Tage, Wochen oder Monate abhängig vom gewählten Backup. Für manuelle Backups werden nur die letzten X Dateien behalten."
+        }
+      }
     }
   }
+}

--- a/custom_components/tally_list/translations/en.json
+++ b/custom_components/tally_list/translations/en.json
@@ -150,5 +150,81 @@
           "back": "Back"
         }
       }
+  },
+  "services": {
+    "add_drink": {
+      "name": "Add drink",
+      "description": "Increment drink counter for a person",
+      "fields": {
+        "user": {
+          "name": "Person name",
+          "description": "Person name"
+        },
+        "drink": {
+          "name": "Drink name",
+          "description": "Drink name"
+        }
+      }
+    },
+    "remove_drink": {
+      "name": "Remove drink",
+      "description": "Decrement drink counter for a person",
+      "fields": {
+        "user": {
+          "name": "Person name",
+          "description": "Person name"
+        },
+        "drink": {
+          "name": "Drink name",
+          "description": "Drink name"
+        }
+      }
+    },
+    "adjust_count": {
+      "name": "Adjust count",
+      "description": "Set drink count for a person",
+      "fields": {
+        "user": {
+          "name": "Person name",
+          "description": "Person name"
+        },
+        "drink": {
+          "name": "Drink name",
+          "description": "Drink name"
+        },
+        "count": {
+          "name": "Count",
+          "description": "Desired drink count"
+        }
+      }
+    },
+    "reset_counters": {
+      "name": "Reset counters",
+      "description": "Reset counters for a person. If no user is specified, reset all.",
+      "fields": {
+        "user": {
+          "name": "Person name",
+          "description": "Person name"
+        }
+      }
+    },
+    "export_csv": {
+      "name": "Export CSV",
+      "description": "Export all amount_due sensors to CSV files",
+      "fields": {
+        "backup": {
+          "name": "Backup type",
+          "description": "Type of backup to create"
+        },
+        "interval": {
+          "name": "Interval",
+          "description": "Create a backup every X days, weeks or months depending on the selected backup. Ignored for manual backups."
+        },
+        "keep": {
+          "name": "Keep",
+          "description": "Delete backups older than X days, weeks or months depending on the selected backup. For manual backups keep only the latest X files."
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add English service translations for all tally list operations
- add German translations for the same services

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891128167dc832e8c84149fe15efa02