### PR TITLE
Allow bilingual price list user

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -40,7 +40,7 @@ Jede Person erhält eine Entität `button.<person>_reset_tally`, um ihre Zähler
 
 ## Preisliste und Sensoren
 
-Alle Getränke werden in einer gemeinsamen Preisliste gespeichert. Ein spezieller Benutzer namens `Preisliste` stellt für jedes Getränk einen Preissensor sowie einen Sensor für den Freibetrag bereit, während normale Personen nur Zähl- und Gesamtbetragssensoren erhalten. Der Freibetrag wird vom Gesamtbetrag jeder Person abgezogen. Getränke, Preise und Freibetrag können jederzeit über die Integrationsoptionen bearbeitet werden.
+Alle Getränke werden in einer gemeinsamen Preisliste gespeichert. Ein spezieller Benutzer namens `Preisliste` (englisch `Price list`) stellt für jedes Getränk einen Preissensor sowie einen Sensor für den Freibetrag bereit, während normale Personen nur Zähl- und Gesamtbetragssensoren erhalten. Der Freibetrag wird vom Gesamtbetrag jeder Person abgezogen. Getränke, Preise und Freibetrag können jederzeit über die Integrationsoptionen bearbeitet werden.
 
 ## WebSocket-API
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Each person gets a `button.<person>_reset_tally` entity to reset all their count
 
 ## Price List and Sensors
 
-All drinks are stored in a single price list. A dedicated user named `Preisliste` exposes one price sensor per drink as well as a free amount sensor, while regular persons only get count and total amount sensors. The free amount is subtracted from each person's total. You can edit drinks, prices and the free amount at any time from the integration options.
+All drinks are stored in a single price list. A dedicated user named `Preisliste` (`Price list` in English) exposes one price sensor per drink as well as a free amount sensor, while regular persons only get count and total amount sensors. The free amount is subtracted from each person's total. You can edit drinks, prices and the free amount at any time from the integration options.
 
 ## WebSocket API
 

--- a/custom_components/tally_list/__init__.py
+++ b/custom_components/tally_list/__init__.py
@@ -27,7 +27,7 @@ from .const import (
     CONF_FREE_AMOUNT,
     CONF_EXCLUDED_USERS,
     CONF_OVERRIDE_USERS,
-    PRICE_LIST_USER,
+    PRICE_LIST_USERS,
     CONF_CURRENCY,
 )
 
@@ -384,7 +384,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
     if unloaded:
         hass.data[DOMAIN].pop(entry.entry_id, None)
-        if entry.data.get(CONF_USER) == PRICE_LIST_USER:
+        if entry.data.get(CONF_USER) in PRICE_LIST_USERS:
             hass.data[DOMAIN].pop("drinks", None)
             hass.data[DOMAIN].pop("free_amount", None)
             hass.data[DOMAIN].pop(CONF_EXCLUDED_USERS, None)

--- a/custom_components/tally_list/button.py
+++ b/custom_components/tally_list/button.py
@@ -13,14 +13,14 @@ from .const import (
     SERVICE_RESET_COUNTERS,
     CONF_USER,
     CONF_OVERRIDE_USERS,
-    PRICE_LIST_USER,
+    PRICE_LIST_USERS,
 )
 
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities
 ):
-    if entry.data[CONF_USER] != PRICE_LIST_USER:
+    if entry.data[CONF_USER] not in PRICE_LIST_USERS:
         async_add_entities([ResetButton(hass, entry)])
 
 

--- a/custom_components/tally_list/config_flow.py
+++ b/custom_components/tally_list/config_flow.py
@@ -19,7 +19,8 @@ from .const import (
     CONF_FREE_AMOUNT,
     CONF_EXCLUDED_USERS,
     CONF_OVERRIDE_USERS,
-    PRICE_LIST_USER,
+    PRICE_LIST_USERS,
+    get_price_list_user,
     CONF_CURRENCY,
 )
 
@@ -94,7 +95,7 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         persons = [
             p
             for p in persons
-            if p not in existing and p not in excluded and p != PRICE_LIST_USER
+            if p not in existing and p not in excluded and p not in PRICE_LIST_USERS
         ]
 
         if not persons:
@@ -105,7 +106,7 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         entries = self.hass.config_entries.async_entries(DOMAIN)
         has_price_user = any(
-            entry.data.get(CONF_USER) == PRICE_LIST_USER for entry in entries
+            entry.data.get(CONF_USER) in PRICE_LIST_USERS for entry in entries
         )
         for entry in entries:
             if CONF_DRINKS in entry.data:
@@ -118,7 +119,9 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                             DOMAIN,
                             context={"source": config_entries.SOURCE_IMPORT},
                             data={
-                                CONF_USER: PRICE_LIST_USER,
+                                CONF_USER: get_price_list_user(
+                                    getattr(self.hass.config, "language", None)
+                                ),
                                 CONF_FREE_AMOUNT: 0.0,
                             },
                         )
@@ -146,7 +149,7 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self.hass.data.setdefault(DOMAIN, {})["drinks"] = self._drinks
 
             has_price_user = any(
-                entry.data.get(CONF_USER) == PRICE_LIST_USER
+                entry.data.get(CONF_USER) in PRICE_LIST_USERS
                 for entry in self.hass.config_entries.async_entries(DOMAIN)
             )
             if not has_price_user:
@@ -155,7 +158,9 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         DOMAIN,
                         context={"source": config_entries.SOURCE_IMPORT},
                         data={
-                            CONF_USER: PRICE_LIST_USER,
+                            CONF_USER: get_price_list_user(
+                                getattr(self.hass.config, "language", None)
+                            ),
                             CONF_FREE_AMOUNT: 0.0,
                         },
                     )
@@ -411,7 +416,7 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
         persons = [
             p
             for p in persons
-            if p not in self._excluded_users and p != PRICE_LIST_USER
+            if p not in self._excluded_users and p not in PRICE_LIST_USERS
         ]
 
         if not persons:
@@ -472,7 +477,7 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
         persons = [
             p
             for p in persons
-            if p not in self._override_users and p != PRICE_LIST_USER
+            if p not in self._override_users and p not in PRICE_LIST_USERS
         ]
 
         if not persons:

--- a/custom_components/tally_list/const.py
+++ b/custom_components/tally_list/const.py
@@ -19,4 +19,15 @@ SERVICE_RESET_COUNTERS = "reset_counters"
 SERVICE_EXPORT_CSV = "export_csv"
 
 # Dedicated user name that exposes drink prices
-PRICE_LIST_USER = "Preisliste"
+PRICE_LIST_USER_DE = "Preisliste"
+PRICE_LIST_USER_EN = "Price list"
+# Default name for backward compatibility
+PRICE_LIST_USER = PRICE_LIST_USER_DE
+PRICE_LIST_USERS = {PRICE_LIST_USER_DE, PRICE_LIST_USER_EN}
+
+
+def get_price_list_user(language: str | None) -> str:
+    """Return localized price list user name."""
+    if language and language.lower().startswith("de"):
+        return PRICE_LIST_USER_DE
+    return PRICE_LIST_USER_EN

--- a/custom_components/tally_list/sensor.py
+++ b/custom_components/tally_list/sensor.py
@@ -7,7 +7,7 @@ from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN, CONF_USER, PRICE_LIST_USER, CONF_CURRENCY
+from .const import DOMAIN, CONF_USER, PRICE_LIST_USERS, CONF_CURRENCY
 
 
 async def async_setup_entry(
@@ -18,7 +18,7 @@ async def async_setup_entry(
     drinks = hass.data[DOMAIN].get("drinks", {})
     sensors: list[SensorEntity] = []
 
-    if user == PRICE_LIST_USER:
+    if user in PRICE_LIST_USERS:
         for drink_name, price in drinks.items():
             sensors.append(DrinkPriceSensor(hass, entry, drink_name, price))
         sensors.append(FreeAmountSensor(hass, entry))


### PR DESCRIPTION
## Summary
- Support both "Preisliste" and "Price list" as the dedicated price list user
- Prevent duplicate price list users and localize the auto-created name
- Document bilingual price list user

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892577fcf7c832ebe8b5db456965b12