### PR TITLE
Ensure price list sensors use English IDs

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -43,6 +43,7 @@ Jede Person erhält eine Entität `button.<person>_reset_tally`, um ihre Zähler
 ## Preisliste und Sensoren
 
 Alle Getränke werden in einer gemeinsamen Preisliste gespeichert. Ein spezieller Benutzer namens `Preisliste` (englisch `Price list`) stellt für jedes Getränk einen Preissensor sowie einen Sensor für den Freibetrag bereit, während normale Personen nur Zähl- und Gesamtbetragssensoren erhalten. Der Freibetrag wird vom Gesamtbetrag jeder Person abgezogen. Getränke, Preise und Freibetrag können jederzeit über die Integrationsoptionen bearbeitet werden.
+Die Sensoren des Preisliste-Benutzers verwenden immer englische Entitäts-IDs mit dem Präfix `price_list`, z. B. `sensor.price_list_free_amount` oder `sensor.price_list_wasser_price`.
 
 ## WebSocket-API
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Each person gets a `button.<person>_reset_tally` entity to reset all their count
 ## Price List and Sensors
 
 All drinks are stored in a single price list. A dedicated user named `Preisliste` (`Price list` in English) exposes one price sensor per drink as well as a free amount sensor, while regular persons only get count and total amount sensors. The free amount is subtracted from each person's total. You can edit drinks, prices and the free amount at any time from the integration options.
+Sensors for the price list user always use English entity IDs prefixed with `price_list`, for example `sensor.price_list_free_amount` or `sensor.price_list_wasser_price`.
 
 ## WebSocket API
 

--- a/custom_components/tally_list/sensor.py
+++ b/custom_components/tally_list/sensor.py
@@ -6,6 +6,7 @@ from homeassistant.components.sensor import SensorEntity
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.util import slugify
 
 from .const import DOMAIN, CONF_USER, PRICE_LIST_USERS, CONF_CURRENCY
 
@@ -95,6 +96,7 @@ class DrinkPriceSensor(SensorEntity):
         self._attr_should_poll = False
         self._attr_name = f"{entry.data[CONF_USER]} {drink} Price"
         self._attr_unique_id = f"{entry.entry_id}_{drink}_price"
+        self.entity_id = f"sensor.price_list_{slugify(drink)}_price"
         self._attr_native_unit_of_measurement = hass.data.get(DOMAIN, {}).get(
             CONF_CURRENCY, "€"
         )
@@ -122,6 +124,7 @@ class FreeAmountSensor(SensorEntity):
         self._attr_should_poll = False
         self._attr_name = f"{entry.data[CONF_USER]} Free Amount"
         self._attr_unique_id = f"{entry.entry_id}_free_amount"
+        self.entity_id = "sensor.price_list_free_amount"
         self._attr_native_unit_of_measurement = hass.data.get(DOMAIN, {}).get(
             CONF_CURRENCY, "€"
         )


### PR DESCRIPTION
## Summary
- Force price list sensors to use English `price_list` entity IDs
- Document English entity IDs for the price list user

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68937cab0258832eb16a1e1716b16979