### PR TITLE
fix: preserve excluded users when recreating price list

### DIFF
--- a/custom_components/tally_list/__init__.py
+++ b/custom_components/tally_list/__init__.py
@@ -387,7 +387,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if entry.data.get(CONF_USER) in PRICE_LIST_USERS:
             hass.data[DOMAIN].pop("drinks", None)
             hass.data[DOMAIN].pop("free_amount", None)
-            hass.data[DOMAIN].pop(CONF_EXCLUDED_USERS, None)
+            # Keep excluded users so they are not re-created when the price list
+            # user is re-added later
             hass.data[DOMAIN].pop(CONF_OVERRIDE_USERS, None)
             hass.data[DOMAIN].pop(CONF_CURRENCY, None)
         if not any(

--- a/custom_components/tally_list/config_flow.py
+++ b/custom_components/tally_list/config_flow.py
@@ -91,6 +91,8 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         excluded = set(
             self.hass.data.get(DOMAIN, {}).get(CONF_EXCLUDED_USERS, [])
         )
+        # Preserve already excluded users when the price list user is recreated
+        self._excluded_users = list(excluded)
 
         persons = [
             p


### PR DESCRIPTION
## Summary
- keep excluded users when removing price list entry so they aren't re-created
- reuse stored excluded users during config flow

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68938a52bdc8832e9bdd2acbe1872480