### PR TITLE
Add confirmation warning before cleanup

### DIFF
--- a/custom_components/tally_list/config_flow.py
+++ b/custom_components/tally_list/config_flow.py
@@ -312,17 +312,24 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
         return await self.async_step_remove_override_user(user_input)
 
     async def async_step_cleanup(self, user_input=None):
+        errors = {}
         if user_input is not None:
-            removed = await self._cleanup_unused_entities()
-            if removed:
-                return self.async_show_form(
-                    step_id="cleanup_result",
-                    description_placeholders={
-                        "sensors": "\n- ".join(sorted(removed))
-                    },
-                )
-            return await self.async_step_menu()
-        return self.async_show_form(step_id="cleanup")
+            confirmation = user_input.get("confirm", "").strip().upper()
+            if confirmation in {"JA ICH WILL", "YES I WANT"}:
+                removed = await self._cleanup_unused_entities()
+                if removed:
+                    return self.async_show_form(
+                        step_id="cleanup_result",
+                        description_placeholders={
+                            "sensors": "\n- ".join(sorted(removed))
+                        },
+                    )
+                return await self.async_step_menu()
+            errors["base"] = "invalid_confirmation"
+        schema = vol.Schema({vol.Required("confirm"): str})
+        return self.async_show_form(
+            step_id="cleanup", data_schema=schema, errors=errors
+        )
 
     async def async_step_cleanup_result(self, user_input=None):
         return await self.async_step_menu()

--- a/custom_components/tally_list/translations/de.json
+++ b/custom_components/tally_list/translations/de.json
@@ -30,6 +30,9 @@
     }
   },
   "options": {
+      "error": {
+        "invalid_confirmation": "Bitte gib \"JA ICH WILL\" ein."
+      },
       "step": {
         "menu": {
           "title": "Strichliste verwalten",
@@ -125,7 +128,11 @@
           }
         },
         "cleanup": {
-          "title": "Nicht mehr genutzte Sensoren entfernen"
+          "title": "Nicht mehr genutzte Sensoren entfernen",
+          "description": "Dies löscht auch alle offenen 'zu zahlende Beträge'. Gib zur Bestätigung \"JA ICH WILL\" ein.",
+          "data": {
+            "confirm": "Bestätigung"
+          }
         },
         "cleanup_result": {
           "title": "Nicht genutzte Sensoren entfernt",

--- a/custom_components/tally_list/translations/en.json
+++ b/custom_components/tally_list/translations/en.json
@@ -30,6 +30,9 @@
     }
   },
   "options": {
+    "error": {
+      "invalid_confirmation": "Please type \"YES I WANT\"."
+    },
     "step": {
         "menu": {
           "title": "Tally List Options",
@@ -125,7 +128,11 @@
           }
         },
         "cleanup": {
-          "title": "Remove unused sensors"
+          "title": "Remove unused sensors",
+          "description": "This will also remove all open 'amount due' values. Type \"YES I WANT\" to confirm.",
+          "data": {
+            "confirm": "Confirmation"
+          }
         },
         "cleanup_result": {
           "title": "Unused sensors removed",


### PR DESCRIPTION
## Summary
- require explicit phrase before running cleanup to avoid accidental deletion of outstanding amounts
- document confirmation phrase in German and English translations

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893909a05bc832ebc2238629b40fcf9