### PR TITLE
Improve unused sensor cleanup feedback

### DIFF
--- a/custom_components/tally_list/config_flow.py
+++ b/custom_components/tally_list/config_flow.py
@@ -324,7 +324,7 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
                             "sensors": "\n- ".join(sorted(removed))
                         },
                     )
-                return await self.async_step_menu()
+                return self.async_show_form(step_id="cleanup_result_empty")
             errors["base"] = "invalid_confirmation"
         schema = vol.Schema({vol.Required("confirm"): str})
         return self.async_show_form(
@@ -332,6 +332,9 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
         )
 
     async def async_step_cleanup_result(self, user_input=None):
+        return await self.async_step_menu()
+
+    async def async_step_cleanup_result_empty(self, user_input=None):
         return await self.async_step_menu()
 
     async def async_step_finish(self, user_input=None):

--- a/custom_components/tally_list/translations/de.json
+++ b/custom_components/tally_list/translations/de.json
@@ -136,7 +136,11 @@
         },
         "cleanup_result": {
           "title": "Nicht genutzte Sensoren entfernt",
-          "description": "Folgende Sensoren wurden entfernt:\n- {sensors}\nDabei wurden auch gespeicherte 'zu zahlende Betr\u00e4ge' zur\u00fcckgesetzt."
+          "description": "Folgende Sensoren wurden entfernt:\n- {sensors}"
+        },
+        "cleanup_result_empty": {
+          "title": "Keine ungenutzten Sensoren gefunden",
+          "description": "Es wurden keine ungenutzten Sensoren gefunden."
         }
       },
       "enum": {

--- a/custom_components/tally_list/translations/en.json
+++ b/custom_components/tally_list/translations/en.json
@@ -136,7 +136,11 @@
         },
         "cleanup_result": {
           "title": "Unused sensors removed",
-          "description": "Removed unused sensors:\n- {sensors}\nThis also resets stored 'amount due' values."
+          "description": "Removed unused sensors:\n- {sensors}"
+        },
+        "cleanup_result_empty": {
+          "title": "No unused sensors found",
+          "description": "No unused sensors were found."
         }
       },
       "enum": {


### PR DESCRIPTION
## Summary
- remove "amount due" reset note from unused sensor cleanup
- show message when no unused sensors are found

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893931b1b64832eb83b072e6559eba3