### PR TITLE
Ensure sensor entity IDs remain English

### DIFF
--- a/custom_components/tally_list/sensor.py
+++ b/custom_components/tally_list/sensor.py
@@ -47,6 +47,9 @@ class TallyListSensor(RestoreEntity, SensorEntity):
         self._attr_should_poll = False
         self._attr_name = f"{entry.data[CONF_USER]} {drink} Count"
         self._attr_unique_id = f"{entry.entry_id}_{drink}_count"
+        self.entity_id = (
+            f"sensor.{slugify(entry.data[CONF_USER])}_{slugify(drink)}_count"
+        )
         self._attr_native_value = 0
         self._attr_native_unit_of_measurement = None
 
@@ -151,6 +154,7 @@ class TotalAmountSensor(RestoreEntity, SensorEntity):
         self._attr_should_poll = False
         self._attr_name = f"{entry.data[CONF_USER]} Amount Due"
         self._attr_unique_id = f"{entry.entry_id}_amount_due"
+        self.entity_id = f"sensor.{slugify(entry.data[CONF_USER])}_amount_due"
         self._attr_native_unit_of_measurement = hass.data.get(DOMAIN, {}).get(
             CONF_CURRENCY, "€"
         )


### PR DESCRIPTION
## Summary
- Keep drink count sensors' entity IDs in English
- Keep amount due sensor's entity ID in English

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68939dbeba18832eb66f0e6b30c20919