### PR TITLE
fix KeyError when setting up entry

### DIFF
--- a/custom_components/tally_list/__init__.py
+++ b/custom_components/tally_list/__init__.py
@@ -280,10 +280,16 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up a config entry."""
-    hass.data[DOMAIN].setdefault(
-        entry.entry_id,
-        {"entry": entry, "counts": {}},
+    hass.data.setdefault(
+        DOMAIN,
+        {
+            "drinks": {},
+            CONF_EXCLUDED_USERS: [],
+            CONF_OVERRIDE_USERS: [],
+            CONF_CURRENCY: "€",
+        },
     )
+    hass.data[DOMAIN].setdefault(entry.entry_id, {"entry": entry, "counts": {}})
     if not hass.data[DOMAIN].get("drinks") and entry.data.get("drinks"):
         hass.data[DOMAIN]["drinks"] = entry.data["drinks"]
     if hass.data[DOMAIN].get("drinks") and not entry.data.get("drinks"):


### PR DESCRIPTION
## Summary
- avoid KeyError when setting up tally_list entry

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893a0c64784832eb7f071f860d43881