### PR TITLE
Fix missing price list updates when adding drinks

### DIFF
--- a/custom_components/tally_list/config_flow.py
+++ b/custom_components/tally_list/config_flow.py
@@ -151,6 +151,16 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 return await self.async_step_add_drink()
             self.hass.data.setdefault(DOMAIN, {})["drinks"] = self._drinks
 
+            for entry in self.hass.config_entries.async_entries(DOMAIN):
+                if entry.data.get(CONF_USER) in PRICE_LIST_USERS:
+                    entry_data = dict(entry.data)
+                    entry_data[CONF_DRINKS] = self._drinks
+                    self.hass.config_entries.async_update_entry(
+                        entry, data=entry_data
+                    )
+                    await self.hass.config_entries.async_reload(entry.entry_id)
+                    break
+
             has_price_user = any(
                 entry.data.get(CONF_USER) in PRICE_LIST_USERS
                 for entry in self.hass.config_entries.async_entries(DOMAIN)
@@ -165,6 +175,7 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                                 getattr(self.hass.config, "language", None)
                             ),
                             CONF_FREE_AMOUNT: 0.0,
+                            CONF_DRINKS: self._drinks,
                         },
                     )
                 )


### PR DESCRIPTION
## Summary
- Reload price list entry after adding drinks so the price list includes updated prices
- Pass drinks to new price list entry creation

## Testing
- `python -m pytest`
- `python -m py_compile custom_components/tally_list/config_flow.py`


------
https://chatgpt.com/codex/tasks/task_e_6893a29a2c30832e8eb358eb7d81e9e9