### PR TITLE
Add user management options to config flow

### DIFF
--- a/custom_components/tally_list/translations/de.json
+++ b/custom_components/tally_list/translations/de.json
@@ -23,6 +23,52 @@
         "data": {
           "currency": "Währung"
         }
+      },
+      "menu": {
+        "title": "Strichliste konfigurieren",
+        "menu_options": {
+          "free_amount": "Freibetrag setzen",
+          "exclude": "Person ausschließen",
+          "include": "Person einschließen",
+          "authorize": "Adminrechte vergeben",
+          "unauthorize": "Adminrechte entziehen",
+          "currency": "Währung setzen",
+          "finish": "Fertig"
+        }
+      },
+      "set_free_amount": {
+        "title": "Freibetrag setzen",
+        "data": {
+          "free_amount": "Freibetrag"
+        }
+      },
+      "add_excluded_user": {
+        "title": "Person ausschließen",
+        "data": {
+          "user": "Person",
+          "add_more": "Weiteren ausschließen"
+        }
+      },
+      "remove_excluded_user": {
+        "title": "Person einschließen",
+        "data": {
+          "user": "Person",
+          "remove_more": "Weiteren einschließen"
+        }
+      },
+      "add_override_user": {
+        "title": "Adminrechte vergeben",
+        "data": {
+          "user": "Person",
+          "add_more": "Weiteren berechtigen"
+        }
+      },
+      "remove_override_user": {
+        "title": "Adminrechte entziehen",
+        "data": {
+          "user": "Person",
+          "remove_more": "Weiteren entziehen"
+        }
       }
     },
     "error": {

--- a/custom_components/tally_list/translations/en.json
+++ b/custom_components/tally_list/translations/en.json
@@ -23,6 +23,52 @@
         "data": {
           "currency": "Currency"
         }
+      },
+      "menu": {
+        "title": "Configure Tally List",
+        "menu_options": {
+          "free_amount": "Set free amount",
+          "exclude": "Exclude person",
+          "include": "Include person",
+          "authorize": "Grant admin rights",
+          "unauthorize": "Revoke admin rights",
+          "currency": "Set currency",
+          "finish": "Finish"
+        }
+      },
+      "set_free_amount": {
+        "title": "Set Free Amount",
+        "data": {
+          "free_amount": "Free amount"
+        }
+      },
+      "add_excluded_user": {
+        "title": "Exclude Person",
+        "data": {
+          "user": "Person",
+          "add_more": "Exclude another"
+        }
+      },
+      "remove_excluded_user": {
+        "title": "Include Person",
+        "data": {
+          "user": "Person",
+          "remove_more": "Include another"
+        }
+      },
+      "add_override_user": {
+        "title": "Grant Admin Rights",
+        "data": {
+          "user": "Person",
+          "add_more": "Authorize another"
+        }
+      },
+      "remove_override_user": {
+        "title": "Revoke Admin Rights",
+        "data": {
+          "user": "Person",
+          "remove_more": "Unauthorize another"
+        }
       }
     },
     "error": {


### PR DESCRIPTION
## Summary
- allow setting free amount, excluding/including users, and granting/revoking admin rights during initial configuration
- update English and German translations for the new menu

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893a6458a88832eae3bddd71e9a1808