### PR TITLE
Delay creation of users until config setup completes

### DIFF
--- a/custom_components/tally_list/config_flow.py
+++ b/custom_components/tally_list/config_flow.py
@@ -56,6 +56,8 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._override_users: list[str] = []
         self._pending_users: list[str] = []
         self._currency: str = "€"
+        self._create_price_user: bool = False
+        self._user_selected: bool = False
 
     async def async_step_import(self, user_input=None):
         """Handle import of a config entry."""
@@ -72,6 +74,179 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return self.async_create_entry(title=self._user, data=user_input)
 
     async def async_step_user(self, user_input=None):
+        if not self._user_selected:
+            registry = er.async_get(self.hass)
+            persons = [
+                entry.original_name or entry.name or entry.entity_id
+                for entry in registry.entities.values()
+                if entry.domain == "person"
+                and (
+                    (state := self.hass.states.get(entry.entity_id))
+                    and state.attributes.get("user_id")
+                )
+            ]
+
+            existing = {
+                entry.data.get(CONF_USER)
+                for entry in self.hass.config_entries.async_entries(DOMAIN)
+            }
+
+            excluded = set(
+                self.hass.data.get(DOMAIN, {}).get(CONF_EXCLUDED_USERS, [])
+            )
+            # Preserve already excluded users when the price list user is recreated
+            self._excluded_users = list(excluded)
+
+            persons = [
+                p
+                for p in persons
+                if p not in existing and p not in excluded and p not in PRICE_LIST_USERS
+            ]
+
+            entries = self.hass.config_entries.async_entries(DOMAIN)
+            self._create_price_user = not any(
+                entry.data.get(CONF_USER) in PRICE_LIST_USERS for entry in entries
+            )
+
+            if not persons:
+                return self.async_abort(reason="no_users")
+
+            self._user = persons[0]
+            self._pending_users = persons[1:]
+            for entry in entries:
+                if CONF_DRINKS in entry.data:
+                    self._drinks = entry.data[CONF_DRINKS]
+                    self._excluded_users = entry.data.get(CONF_EXCLUDED_USERS, [])
+                    self._override_users = entry.data.get(CONF_OVERRIDE_USERS, [])
+                    self._free_amount = float(entry.data.get(CONF_FREE_AMOUNT, 0.0))
+                    self._currency = entry.data.get(CONF_CURRENCY, "€")
+                    break
+            self._user_selected = True
+            return await self.async_step_menu()
+
+        return self.async_show_menu(
+            step_id="user",
+            menu_options=[
+                "free_amount",
+                "exclude",
+                "include",
+                "authorize",
+                "unauthorize",
+                "back",
+            ],
+        )
+
+    async def async_step_menu(self, user_input=None):
+        return self.async_show_menu(
+            step_id="menu",
+            menu_options=["user", "drinks", "cleanup", "finish"],
+        )
+
+    async def async_step_drinks(self, user_input=None):
+        return self.async_show_menu(
+            step_id="drinks",
+            menu_options=["add", "remove", "edit", "currency", "back"],
+        )
+
+    async def async_step_back(self, user_input=None):
+        return await self.async_step_menu()
+
+    async def async_step_add(self, user_input=None):
+        return await self.async_step_add_drink(user_input)
+
+    async def async_step_remove(self, user_input=None):
+        return await self.async_step_remove_drink(user_input)
+
+    async def async_step_edit(self, user_input=None):
+        return await self.async_step_edit_price(user_input)
+
+    async def async_step_free_amount(self, user_input=None):
+        return await self.async_step_set_free_amount(user_input)
+
+    async def async_step_currency(self, user_input=None):
+        if user_input is not None:
+            self._currency = user_input[CONF_CURRENCY]
+            return await self.async_step_menu()
+        schema = vol.Schema({vol.Required(CONF_CURRENCY, default=self._currency): str})
+        return self.async_show_form(step_id="currency", data_schema=schema)
+
+    async def async_step_exclude(self, user_input=None):
+        return await self.async_step_add_excluded_user(user_input)
+
+    async def async_step_include(self, user_input=None):
+        return await self.async_step_remove_excluded_user(user_input)
+
+    async def async_step_authorize(self, user_input=None):
+        return await self.async_step_add_override_user(user_input)
+
+    async def async_step_unauthorize(self, user_input=None):
+        return await self.async_step_remove_override_user(user_input)
+
+    async def async_step_add_drink(self, user_input=None):
+        if user_input is not None:
+            drink = user_input[CONF_DRINK]
+            price = float(user_input[CONF_PRICE])
+            self._drinks[drink] = price
+            if user_input.get("add_more"):
+                return await self.async_step_add_drink()
+            return await self.async_step_menu()
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_DRINK): str,
+                vol.Required(CONF_PRICE): vol.Coerce(float),
+                vol.Optional("add_more", default=False): bool,
+            }
+        )
+        return self.async_show_form(step_id="add_drink", data_schema=schema)
+
+    async def async_step_remove_drink(self, user_input=None):
+        if user_input is not None:
+            drink = user_input[CONF_DRINK]
+            self._drinks.pop(drink, None)
+            if user_input.get("remove_more") and self._drinks:
+                return await self.async_step_remove_drink()
+            return await self.async_step_menu()
+        if not self._drinks:
+            return await self.async_step_menu()
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_DRINK): vol.In(list(self._drinks.keys())),
+                vol.Optional("remove_more", default=False): bool,
+            }
+        )
+        return self.async_show_form(step_id="remove_drink", data_schema=schema)
+
+    async def async_step_edit_price(self, user_input=None):
+        if user_input is not None:
+            drink = user_input[CONF_DRINK]
+            price = float(user_input[CONF_PRICE])
+            self._drinks[drink] = price
+            if user_input.get("edit_more") and self._drinks:
+                return await self.async_step_edit_price()
+            return await self.async_step_menu()
+        if not self._drinks:
+            return await self.async_step_menu()
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_DRINK): vol.In(list(self._drinks.keys())),
+                vol.Required(CONF_PRICE): vol.Coerce(float),
+                vol.Optional("edit_more", default=False): bool,
+            }
+        )
+        return self.async_show_form(step_id="edit_price", data_schema=schema)
+
+    async def async_step_set_free_amount(self, user_input=None):
+        if user_input is not None:
+            self._free_amount = float(user_input[CONF_FREE_AMOUNT])
+            return await self.async_step_menu()
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_FREE_AMOUNT, default=self._free_amount): vol.Coerce(float)
+            }
+        )
+        return self.async_show_form(step_id="set_free_amount", data_schema=schema)
+
+    async def async_step_add_excluded_user(self, user_input=None):
         registry = er.async_get(self.hass)
         persons = [
             entry.original_name or entry.name or entry.entity_id
@@ -82,29 +257,134 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 and state.attributes.get("user_id")
             )
         ]
-
-        existing = {
-            entry.data.get(CONF_USER)
-            for entry in self.hass.config_entries.async_entries(DOMAIN)
-        }
-
-        excluded = set(
-            self.hass.data.get(DOMAIN, {}).get(CONF_EXCLUDED_USERS, [])
-        )
-        # Preserve already excluded users when the price list user is recreated
-        self._excluded_users = list(excluded)
-
         persons = [
-            p
-            for p in persons
-            if p not in existing and p not in excluded and p not in PRICE_LIST_USERS
+            p for p in persons if p not in self._excluded_users and p not in PRICE_LIST_USERS
         ]
-
-        entries = self.hass.config_entries.async_entries(DOMAIN)
-        has_price_user = any(
-            entry.data.get(CONF_USER) in PRICE_LIST_USERS for entry in entries
+        if not persons:
+            return await self.async_step_menu()
+        if user_input is not None:
+            user = user_input[CONF_USER]
+            self._excluded_users.append(user)
+            if user_input.get("add_more") and len(persons) > 1:
+                return await self.async_step_add_excluded_user()
+            return await self.async_step_menu()
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_USER): vol.In(persons),
+                vol.Optional("add_more", default=False): bool,
+            }
         )
-        if not has_price_user:
+        return self.async_show_form(step_id="add_excluded_user", data_schema=schema)
+
+    async def async_step_remove_excluded_user(self, user_input=None):
+        if user_input is not None:
+            user = user_input[CONF_USER]
+            if user in self._excluded_users:
+                self._excluded_users.remove(user)
+            if user_input.get("remove_more") and self._excluded_users:
+                return await self.async_step_remove_excluded_user()
+            return await self.async_step_menu()
+        if not self._excluded_users:
+            return await self.async_step_menu()
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_USER): vol.In(list(self._excluded_users)),
+                vol.Optional("remove_more", default=False): bool,
+            }
+        )
+        return self.async_show_form(step_id="remove_excluded_user", data_schema=schema)
+
+    async def async_step_add_override_user(self, user_input=None):
+        registry = er.async_get(self.hass)
+        persons = [
+            entry.original_name or entry.name or entry.entity_id
+            for entry in registry.entities.values()
+            if entry.domain == "person"
+            and (
+                (state := self.hass.states.get(entry.entity_id))
+                and state.attributes.get("user_id")
+            )
+        ]
+        persons = [
+            p for p in persons if p not in self._override_users and p not in PRICE_LIST_USERS
+        ]
+        if not persons:
+            return await self.async_step_menu()
+        if user_input is not None:
+            user = user_input[CONF_USER]
+            self._override_users.append(user)
+            if user_input.get("add_more") and len(persons) > 1:
+                return await self.async_step_add_override_user()
+            return await self.async_step_menu()
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_USER): vol.In(persons),
+                vol.Optional("add_more", default=False): bool,
+            }
+        )
+        return self.async_show_form(step_id="add_override_user", data_schema=schema)
+
+    async def async_step_remove_override_user(self, user_input=None):
+        if user_input is not None:
+            user = user_input[CONF_USER]
+            if user in self._override_users:
+                self._override_users.remove(user)
+            if user_input.get("remove_more") and self._override_users:
+                return await self.async_step_remove_override_user()
+            return await self.async_step_menu()
+        if not self._override_users:
+            return await self.async_step_menu()
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_USER): vol.In(list(self._override_users)),
+                vol.Optional("remove_more", default=False): bool,
+            }
+        )
+        return self.async_show_form(step_id="remove_override_user", data_schema=schema)
+
+    async def async_step_cleanup(self, user_input=None):
+        errors = {}
+        if user_input is not None:
+            confirmation = user_input.get("confirm", "").strip().upper()
+            if confirmation in {"JA ICH WILL", "YES I WANT"}:
+                removed = await self._cleanup_unused_entities()
+                if removed:
+                    return self.async_show_form(
+                        step_id="cleanup_result",
+                        description_placeholders={"sensors": "\n- ".join(sorted(removed))},
+                    )
+                return self.async_show_form(step_id="cleanup_result_empty")
+            errors["base"] = "invalid_confirmation"
+        schema = vol.Schema({vol.Required("confirm"): str})
+        return self.async_show_form(step_id="cleanup", data_schema=schema, errors=errors)
+
+    async def async_step_cleanup_result(self, user_input=None):
+        return await self.async_step_menu()
+
+    async def async_step_cleanup_result_empty(self, user_input=None):
+        return await self.async_step_menu()
+
+    async def async_step_finish(self, user_input=None):
+        await self._finalize_setup()
+        return self.async_create_entry(
+            title=self._user,
+            data={
+                CONF_USER: self._user,
+                CONF_DRINKS: self._drinks,
+                CONF_FREE_AMOUNT: self._free_amount,
+                CONF_EXCLUDED_USERS: self._excluded_users,
+                CONF_OVERRIDE_USERS: self._override_users,
+                CONF_CURRENCY: self._currency,
+            },
+        )
+
+    async def _finalize_setup(self) -> None:
+        self.hass.data.setdefault(DOMAIN, {})["drinks"] = self._drinks
+        self.hass.data[DOMAIN]["free_amount"] = self._free_amount
+        self.hass.data[DOMAIN][CONF_EXCLUDED_USERS] = self._excluded_users
+        self.hass.data[DOMAIN][CONF_OVERRIDE_USERS] = self._override_users
+        self.hass.data[DOMAIN][CONF_CURRENCY] = self._currency
+        if self._create_price_user:
             self.hass.async_create_task(
                 self.hass.config_entries.flow.async_init(
                     DOMAIN,
@@ -113,110 +393,90 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         CONF_USER: get_price_list_user(
                             getattr(self.hass.config, "language", None)
                         ),
-                        CONF_FREE_AMOUNT: 0.0,
+                        CONF_FREE_AMOUNT: self._free_amount,
+                        CONF_DRINKS: self._drinks,
+                        CONF_EXCLUDED_USERS: self._excluded_users,
+                        CONF_OVERRIDE_USERS: self._override_users,
+                        CONF_CURRENCY: self._currency,
                     },
                 )
             )
-            has_price_user = True
-
-        if not persons:
-            return self.async_abort(reason="no_users")
-
-        self._user = persons[0]
-        self._pending_users = persons[1:]
-        for entry in entries:
-            if CONF_DRINKS in entry.data:
-                self._drinks = entry.data[CONF_DRINKS]
-                self._excluded_users = entry.data.get(CONF_EXCLUDED_USERS, [])
-                self._currency = entry.data.get(CONF_CURRENCY, "€")
-                for p in self._pending_users:
-                    self.hass.async_create_task(
-                        self.hass.config_entries.flow.async_init(
-                            DOMAIN,
-                            context={"source": config_entries.SOURCE_IMPORT},
-                            data={CONF_USER: p},
-                        )
-                    )
-                self._pending_users = []
-                return await self.async_step_set_currency()
-
-        return await self.async_step_add_drink()
-
-    async def async_step_add_drink(self, user_input=None):
-        if user_input is not None:
-            drink = user_input[CONF_DRINK]
-            price = float(user_input[CONF_PRICE])
-            self._drinks[drink] = price
-            if user_input.get("add_more"):
-                return await self.async_step_add_drink()
-            self.hass.data.setdefault(DOMAIN, {})["drinks"] = self._drinks
-
+        else:
             for entry in self.hass.config_entries.async_entries(DOMAIN):
                 if entry.data.get(CONF_USER) in PRICE_LIST_USERS:
                     entry_data = dict(entry.data)
                     entry_data[CONF_DRINKS] = self._drinks
-                    self.hass.config_entries.async_update_entry(
-                        entry, data=entry_data
-                    )
+                    entry_data[CONF_FREE_AMOUNT] = self._free_amount
+                    entry_data[CONF_EXCLUDED_USERS] = self._excluded_users
+                    entry_data[CONF_OVERRIDE_USERS] = self._override_users
+                    entry_data[CONF_CURRENCY] = self._currency
+                    self.hass.config_entries.async_update_entry(entry, data=entry_data)
                     await self.hass.config_entries.async_reload(entry.entry_id)
                     break
-
-            has_price_user = any(
-                entry.data.get(CONF_USER) in PRICE_LIST_USERS
-                for entry in self.hass.config_entries.async_entries(DOMAIN)
-            )
-            if not has_price_user:
-                self.hass.async_create_task(
-                    self.hass.config_entries.flow.async_init(
-                        DOMAIN,
-                        context={"source": config_entries.SOURCE_IMPORT},
-                        data={
-                            CONF_USER: get_price_list_user(
-                                getattr(self.hass.config, "language", None)
-                            ),
-                            CONF_FREE_AMOUNT: 0.0,
-                            CONF_DRINKS: self._drinks,
-                        },
-                    )
+        for p in self._pending_users:
+            self.hass.async_create_task(
+                self.hass.config_entries.flow.async_init(
+                    DOMAIN,
+                    context={"source": config_entries.SOURCE_IMPORT},
+                    data={CONF_USER: p},
                 )
-            for p in self._pending_users:
-                self.hass.async_create_task(
-                    self.hass.config_entries.flow.async_init(
-                        DOMAIN,
-                        context={"source": config_entries.SOURCE_IMPORT},
-                        data={CONF_USER: p},
-                    )
-                )
-            self._pending_users = []
-            return await self.async_step_set_currency()
-
-        schema = vol.Schema(
-            {
-                vol.Required(CONF_DRINK): str,
-                vol.Required(CONF_PRICE): vol.Coerce(float),
-                vol.Optional("add_more", default=False): bool,
-            }
-        )
-        return self.async_show_form(step_id="add_drink", data_schema=schema)
-
-    async def async_step_set_currency(self, user_input=None):
-        if user_input is not None:
-            self._currency = user_input[CONF_CURRENCY]
-            return self.async_create_entry(
-                title=self._user,
-                data={
-                    CONF_USER: self._user,
-                    CONF_DRINKS: self._drinks,
-                    CONF_FREE_AMOUNT: 0.0,
-                    CONF_EXCLUDED_USERS: self._excluded_users,
-                    CONF_CURRENCY: self._currency,
-                },
             )
-        schema = vol.Schema(
-            {vol.Required(CONF_CURRENCY, default=self._currency): str}
-        )
-        return self.async_show_form(step_id="set_currency", data_schema=schema)
+        self._pending_users = []
 
+    async def _cleanup_unused_entities(self) -> list[str]:
+        registry = er.async_get(self.hass)
+        entries = self.hass.config_entries.async_entries(DOMAIN)
+        entry_ids = {entry.entry_id for entry in entries}
+        active_users = {entry.data.get(CONF_USER) for entry in entries}
+        active_drinks = set(self._drinks.keys())
+        to_remove: list[str] = []
+        for entity_entry in list(registry.entities.values()):
+            if (
+                entity_entry.domain != "sensor" or entity_entry.platform != DOMAIN
+            ):
+                continue
+            if entity_entry.config_entry_id not in entry_ids:
+                to_remove.append(entity_entry.entity_id)
+                continue
+            cfg_entry = next(
+                (e for e in entries if e.entry_id == entity_entry.config_entry_id),
+                None,
+            )
+            if not cfg_entry:
+                to_remove.append(entity_entry.entity_id)
+                continue
+            user = cfg_entry.data.get(CONF_USER)
+            if user not in active_users:
+                to_remove.append(entity_entry.entity_id)
+                continue
+            uid = entity_entry.unique_id or ""
+            prefix = f"{cfg_entry.entry_id}_"
+            if not uid.startswith(prefix):
+                continue
+            if uid.endswith("_count"):
+                drink = uid[len(prefix):-6]
+            elif uid.endswith("_price"):
+                drink = uid[len(prefix):-6]
+            elif uid.endswith("_free_amount"):
+                drink = None
+            elif uid.endswith("_amount_due") or uid.endswith("_reset_tally"):
+                drink = None
+            else:
+                continue
+            if drink is not None and drink not in active_drinks:
+                to_remove.append(entity_entry.entity_id)
+        if to_remove:
+            for entity_id in to_remove:
+                try:
+                    await registry.async_remove(entity_id)
+                except Exception as exc:  # pragma: no cover
+                    _LOGGER.error("Failed to remove %s: %s", entity_id, exc)
+            for entry in entries:
+                self.hass.async_create_task(
+                    self.hass.config_entries.async_reload(entry.entry_id)
+                )
+            return sorted(to_remove)
+        return []
     @staticmethod
     @callback
     def async_get_options_flow(config_entry):

--- a/custom_components/tally_list/translations/de.json
+++ b/custom_components/tally_list/translations/de.json
@@ -5,28 +5,118 @@
       "no_users": "Keine Personen mit Benutzerkonto gefunden"
     },
     "step": {
+      "menu": {
+        "title": "Strichliste verwalten",
+        "menu_options": {
+          "user": "Nutzereinstellungen",
+          "drinks": "Getränkeeinstellungen",
+          "cleanup": "Nicht mehr genutzte Sensoren entfernen",
+          "finish": "Fertig"
+        }
+      },
       "user": {
-        "title": "Strichliste konfigurieren",
-        "description": "Alle Personen mit Benutzerkonto werden automatisch hinzugefügt. Getränke werden einmalig definiert und geteilt."
+        "title": "Nutzereinstellungen",
+        "menu_options": {
+          "free_amount": "Freibetrag setzen",
+          "exclude": "Person ausschließen",
+          "include": "Person einschließen",
+          "authorize": "Adminrechte vergeben",
+          "unauthorize": "Adminrechte entziehen",
+          "back": "Zurück"
+        }
+      },
+      "drinks": {
+        "title": "Getränkeeinstellungen",
+        "menu_options": {
+          "add": "Hinzufügen",
+          "remove": "Entfernen",
+          "edit": "Bearbeiten",
+          "currency": "Währung setzen",
+          "back": "Zurück"
+        }
       },
       "add_drink": {
         "title": "Getränk hinzufügen",
-        "description": "Getränk und Preis eingeben. 'Weiteres hinzufügen' aktivieren, um weitere Getränke einzutragen.",
         "data": {
           "drink": "Getränk",
           "price": "Preis",
           "add_more": "Weiteres hinzufügen"
         }
       },
-      "set_currency": {
+      "remove_drink": {
+        "title": "Getränk entfernen",
+        "data": {
+          "drink": "Getränk",
+          "remove_more": "Weiteres entfernen"
+        }
+      },
+      "edit_price": {
+        "title": "Preis bearbeiten",
+        "data": {
+          "drink": "Getränk",
+          "price": "Preis",
+          "edit_more": "Weiteres bearbeiten"
+        }
+      },
+      "set_free_amount": {
+        "title": "Freibetrag setzen",
+        "data": {
+          "free_amount": "Freibetrag"
+        }
+      },
+      "currency": {
         "title": "Währung setzen",
         "data": {
           "currency": "Währung"
         }
+      },
+      "add_excluded_user": {
+        "title": "Person ausschließen",
+        "data": {
+          "user": "Person",
+          "add_more": "Weiteren ausschließen"
+        }
+      },
+      "remove_excluded_user": {
+        "title": "Person einschließen",
+        "data": {
+          "user": "Person",
+          "remove_more": "Weiteren einschließen"
+        }
+      },
+      "add_override_user": {
+        "title": "Adminrechte vergeben",
+        "data": {
+          "user": "Person",
+          "add_more": "Weiteren berechtigen"
+        }
+      },
+      "remove_override_user": {
+        "title": "Adminrechte entziehen",
+        "data": {
+          "user": "Person",
+          "remove_more": "Weiteren entziehen"
+        }
+      },
+      "cleanup": {
+        "title": "Nicht mehr genutzte Sensoren entfernen",
+        "description": "Dies löscht auch alle offenen 'zu zahlende Beträge'. Gib zur Bestätigung \"JA ICH WILL\" ein.",
+        "data": {
+          "confirm": "Bestätigung"
+        }
+      },
+      "cleanup_result": {
+        "title": "Nicht genutzte Sensoren entfernt",
+        "description": "Folgende Sensoren wurden entfernt:\n- {sensors}"
+      },
+      "cleanup_result_empty": {
+        "title": "Keine ungenutzten Sensoren gefunden",
+        "description": "Es wurden keine ungenutzten Sensoren gefunden."
       }
     },
     "error": {
-      "invalid_drinks": "Ungültiges Getränkeformat"
+      "invalid_drinks": "Ungültiges Getränkeformat",
+      "invalid_confirmation": "Bitte gib \"JA ICH WILL\" ein."
     }
   },
   "options": {

--- a/custom_components/tally_list/translations/en.json
+++ b/custom_components/tally_list/translations/en.json
@@ -5,28 +5,118 @@
       "no_users": "No persons with a user account found"
     },
     "step": {
+      "menu": {
+        "title": "Tally List Options",
+        "menu_options": {
+          "user": "User settings",
+          "drinks": "Drink settings",
+          "cleanup": "Remove unused sensors",
+          "finish": "Done"
+        }
+      },
       "user": {
-        "title": "Configure Tally List",
-        "description": "All persons with a user account are added automatically. Drinks are defined once and shared."
+        "title": "User settings",
+        "menu_options": {
+          "free_amount": "Set free amount",
+          "exclude": "Exclude person",
+          "include": "Include person",
+          "authorize": "Grant admin rights",
+          "unauthorize": "Revoke admin rights",
+          "back": "Back"
+        }
+      },
+      "drinks": {
+        "title": "Drink settings",
+        "menu_options": {
+          "add": "Add drink",
+          "remove": "Remove drink",
+          "edit": "Edit price",
+          "currency": "Set currency",
+          "back": "Back"
+        }
       },
       "add_drink": {
         "title": "Add Drink",
-        "description": "Enter a drink and price. Enable 'Add another' to continue adding drinks.",
         "data": {
           "drink": "Drink name",
           "price": "Price",
           "add_more": "Add another"
         }
       },
-      "set_currency": {
+      "remove_drink": {
+        "title": "Remove Drink",
+        "data": {
+          "drink": "Drink",
+          "remove_more": "Remove another"
+        }
+      },
+      "edit_price": {
+        "title": "Edit Price",
+        "data": {
+          "drink": "Drink",
+          "price": "Price",
+          "edit_more": "Edit another"
+        }
+      },
+      "set_free_amount": {
+        "title": "Set Free Amount",
+        "data": {
+          "free_amount": "Free amount"
+        }
+      },
+      "currency": {
         "title": "Set Currency",
         "data": {
           "currency": "Currency"
         }
+      },
+      "add_excluded_user": {
+        "title": "Exclude Person",
+        "data": {
+          "user": "Person",
+          "add_more": "Exclude another"
+        }
+      },
+      "remove_excluded_user": {
+        "title": "Include Person",
+        "data": {
+          "user": "Person",
+          "remove_more": "Include another"
+        }
+      },
+      "add_override_user": {
+        "title": "Grant Admin Rights",
+        "data": {
+          "user": "Person",
+          "add_more": "Authorize another"
+        }
+      },
+      "remove_override_user": {
+        "title": "Revoke Admin Rights",
+        "data": {
+          "user": "Person",
+          "remove_more": "Unauthorize another"
+        }
+      },
+      "cleanup": {
+        "title": "Remove unused sensors",
+        "description": "This will also remove all open 'amount due' values. Type \"YES I WANT\" to confirm.",
+        "data": {
+          "confirm": "Confirmation"
+        }
+      },
+      "cleanup_result": {
+        "title": "Unused sensors removed",
+        "description": "Removed unused sensors:\n- {sensors}"
+      },
+      "cleanup_result_empty": {
+        "title": "No unused sensors found",
+        "description": "No unused sensors were found."
       }
     },
     "error": {
-      "invalid_drinks": "Invalid drinks format"
+      "invalid_drinks": "Invalid drinks format",
+      "invalid_confirmation": "Please type \"YES I WANT\"."
     }
   },
   "options": {


### PR DESCRIPTION
## Summary
- Mirror options flow within config setup to configure drinks, user permissions, and currency before finalizing
- Defer creation of price list and user entries until configuration is finished
- Add translations for new config flow steps

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893ab566618832eb369a7e4b9d081b3