### PR TITLE
fix: skip creation of excluded users

### DIFF
--- a/custom_components/tally_list/config_flow.py
+++ b/custom_components/tally_list/config_flow.py
@@ -267,6 +267,8 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             user = user_input[CONF_USER]
             self._excluded_users.append(user)
+            if user in self._pending_users:
+                self._pending_users.remove(user)
             if user_input.get("add_more") and len(persons) > 1:
                 return await self.async_step_add_excluded_user()
             return await self.async_step_menu()
@@ -283,6 +285,8 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             user = user_input[CONF_USER]
             if user in self._excluded_users:
                 self._excluded_users.remove(user)
+                if user not in self._pending_users:
+                    self._pending_users.append(user)
             if user_input.get("remove_more") and self._excluded_users:
                 return await self.async_step_remove_excluded_user()
             return await self.async_step_menu()
@@ -396,6 +400,8 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     await self.hass.config_entries.async_reload(entry.entry_id)
                     break
         for p in self._pending_users:
+            if p in self._excluded_users:
+                continue
             self.hass.async_create_task(
                 self.hass.config_entries.flow.async_init(
                     DOMAIN,


### PR DESCRIPTION
## Summary
- avoid creating config entries for excluded users
- re-add users to the queue when they are included again
- filter excluded users during finalize to ensure they stay excluded

## Testing
- `python -m py_compile custom_components/tally_list/config_flow.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893b4fe4a54832e91464b76f06b6a76