### PR TITLE
chore: bump version to v06.08.2025

### DIFF
--- a/custom_components/tally_list/manifest.json
+++ b/custom_components/tally_list/manifest.json
@@ -3,7 +3,7 @@
   "name": "Tally List",
   "documentation": "https://github.com/Spider19996/ha-tally-list",
   "issue_tracker": "https://github.com/Spider19996/ha-tally-list/issues",
-  "version": "1.12.2",
+  "version": "v06.08.2025",
   "requirements": [],
   "config_flow": true,
   "codeowners": ["@Spider19996"],


### PR DESCRIPTION
## Summary
- update integration version to v06.08.2025

## Testing
- `pytest` (no tests ran)


------
https://chatgpt.com/codex/tasks/task_e_6893b9783c88832ebb60a2b0211609ed