### PR TITLE
Allow specifying drink count for add/remove services

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -30,8 +30,8 @@ Beim ersten Einrichten wirst du nach verfügbaren Getränken gefragt. Alle Perso
 
 ### Dienste
 
-- `tally_list.add_drink`: erhöht die Anzahl eines Getränks für eine Person.
-- `tally_list.remove_drink`: verringert die Anzahl eines Getränks für eine Person (nie unter null).
+- `tally_list.add_drink`: erhöht die Anzahl eines Getränks für eine Person (Anzahl kann angegeben werden).
+- `tally_list.remove_drink`: verringert die Anzahl eines Getränks für eine Person (nie unter null; Anzahl kann angegeben werden).
 - `tally_list.adjust_count`: setzt die Anzahl eines Getränks auf einen bestimmten Wert.
 - `tally_list.reset_counters`: setzt alle Zähler für eine Person oder – ohne Angabe einer Person – für alle zurück.
 - `tally_list.export_csv`: exportiert alle `_amount_due`-Sensoren als CSV-Dateien (`daily`, `weekly`, `monthly` oder `manual`), gespeichert unter `/config/backup/tally_list/<type>/`.

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ At initial setup you will be asked to enter available drinks. All persons with a
 
 ### Services
 
-- `tally_list.add_drink`: increment drink count for a person.
-- `tally_list.remove_drink`: decrement drink count for a person (never below zero).
+- `tally_list.add_drink`: increment drink count for a person (optionally specify amount).
+- `tally_list.remove_drink`: decrement drink count for a person (never below zero; optionally specify amount).
 - `tally_list.adjust_count`: set a drink count to a specific value.
 - `tally_list.reset_counters`: reset all counters for a person or for everyone if no user is specified.
 - `tally_list.export_csv`: export all `_amount_due` sensors to CSV files (`daily`, `weekly`, `monthly`, or `manual`) saved under `/config/backup/tally_list/<type>/`.

--- a/custom_components/tally_list/__init__.py
+++ b/custom_components/tally_list/__init__.py
@@ -85,12 +85,13 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         user = call.data[ATTR_USER]
         await _verify_permissions(call, user)
         drink = call.data[ATTR_DRINK]
+        count = max(0, call.data.get("count", 1))
         for entry_id, data in hass.data[DOMAIN].items():
             if not isinstance(data, dict) or "entry" not in data:
                 continue
             if data["entry"].data.get("user") == user:
                 counts = data.setdefault("counts", {})
-                new_count = counts.get(drink, 0) + 1
+                new_count = counts.get(drink, 0) + count
                 counts[drink] = new_count
                 for sensor in data.get("sensors", []):
                     await sensor.async_update_state()
@@ -100,12 +101,13 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         user = call.data[ATTR_USER]
         await _verify_permissions(call, user)
         drink = call.data[ATTR_DRINK]
+        count = max(0, call.data.get("count", 1))
         for entry_id, data in hass.data[DOMAIN].items():
             if not isinstance(data, dict) or "entry" not in data:
                 continue
             if data["entry"].data.get("user") == user:
                 counts = data.setdefault("counts", {})
-                new_count = counts.get(drink, 0) - 1
+                new_count = counts.get(drink, 0) - count
                 if new_count < 0:
                     new_count = 0
                 counts[drink] = new_count

--- a/custom_components/tally_list/manifest.json
+++ b/custom_components/tally_list/manifest.json
@@ -3,7 +3,7 @@
   "name": "Tally List",
   "documentation": "https://github.com/Spider19996/ha-tally-list",
   "issue_tracker": "https://github.com/Spider19996/ha-tally-list/issues",
-  "version": "v06.08.2025",
+  "version": "08.08.2025",
   "requirements": [],
   "config_flow": true,
   "codeowners": ["@Spider19996"],

--- a/custom_components/tally_list/services.yaml
+++ b/custom_components/tally_list/services.yaml
@@ -14,6 +14,14 @@ add_drink:
       required: true
       selector:
         text:
+    count:
+      description: Number of drinks to add
+      example: 2
+      required: false
+      selector:
+        number:
+          min: 1
+          step: 1
 remove_drink:
   name: Remove drink
   description: Decrement drink counter for a person
@@ -30,6 +38,14 @@ remove_drink:
       required: true
       selector:
         text:
+    count:
+      description: Number of drinks to remove
+      example: 2
+      required: false
+      selector:
+        number:
+          min: 1
+          step: 1
 adjust_count:
   name: Adjust count
   description: Set drink count for a person

--- a/custom_components/tally_list/translations/de.json
+++ b/custom_components/tally_list/translations/de.json
@@ -249,6 +249,10 @@
         "drink": {
           "name": "Getränk",
           "description": "Name des Getränks"
+        },
+        "count": {
+          "name": "Anzahl",
+          "description": "Anzahl der hinzuzufügenden Getränke"
         }
       }
     },
@@ -263,6 +267,10 @@
         "drink": {
           "name": "Getränk",
           "description": "Name des Getränks"
+        },
+        "count": {
+          "name": "Anzahl",
+          "description": "Anzahl der zu entfernenden Getränke"
         }
       }
     },

--- a/custom_components/tally_list/translations/en.json
+++ b/custom_components/tally_list/translations/en.json
@@ -249,6 +249,10 @@
         "drink": {
           "name": "Drink name",
           "description": "Drink name"
+        },
+        "count": {
+          "name": "Count",
+          "description": "Number of drinks to add"
         }
       }
     },
@@ -263,6 +267,10 @@
         "drink": {
           "name": "Drink name",
           "description": "Drink name"
+        },
+        "count": {
+          "name": "Count",
+          "description": "Number of drinks to remove"
         }
       }
     },


### PR DESCRIPTION
## Summary
- allow add/remove drink services to accept count parameter
- document optional count in docs and translations
- bump version to 08.08.2025

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895922da954832ebfd62e0fde74e43b