### PR TITLE
Add delete-all option to Tally List options flow

### DIFF
--- a/custom_components/tally_list/translations/de.json
+++ b/custom_components/tally_list/translations/de.json
@@ -115,6 +115,7 @@
             "user": "Nutzereinstellungen",
             "drinks": "Getränkeeinstellungen",
             "cleanup": "Nicht mehr genutzte Sensoren entfernen",
+            "delete": "Alle Einträge löschen",
             "finish": "Fertig"
           }
         },
@@ -209,6 +210,13 @@
             "confirm": "Bestätigung"
           }
         },
+        "delete": {
+          "title": "Alle Einträge löschen",
+          "description": "Dies entfernt alle Sensoren und Konfigurationen dieser Integration. Gib zur Bestätigung \"JA ICH WILL\" ein.",
+          "data": {
+            "confirm": "Bestätigung"
+          }
+        },
         "cleanup_result": {
           "title": "Nicht genutzte Sensoren entfernt",
           "description": "Folgende Sensoren wurden entfernt:\n- {sensors}"
@@ -216,6 +224,10 @@
         "cleanup_result_empty": {
           "title": "Keine ungenutzten Sensoren gefunden",
           "description": "Es wurden keine ungenutzten Sensoren gefunden."
+        },
+        "delete_result": {
+          "title": "Alle Einträge gelöscht",
+          "description": "Alle Sensoren und Konfigurationen wurden entfernt."
         }
       },
       "enum": {
@@ -232,6 +244,7 @@
           "authorize": "Adminrechte vergeben",
           "unauthorize": "Adminrechte entziehen",
           "cleanup": "Nicht mehr genutzte Sensoren entfernen",
+          "delete": "Alle Einträge löschen",
           "finish": "Fertig",
           "back": "Zurück"
         }

--- a/custom_components/tally_list/translations/en.json
+++ b/custom_components/tally_list/translations/en.json
@@ -115,6 +115,7 @@
             "user": "User settings",
             "drinks": "Drink settings",
             "cleanup": "Remove unused sensors",
+            "delete": "Delete all entries",
             "finish": "Done"
           }
         },
@@ -209,6 +210,13 @@
             "confirm": "Confirmation"
           }
         },
+        "delete": {
+          "title": "Delete all entries",
+          "description": "This will remove all sensors and configuration entries of this integration. Type \"YES I WANT\" to confirm.",
+          "data": {
+            "confirm": "Confirmation"
+          }
+        },
         "cleanup_result": {
           "title": "Unused sensors removed",
           "description": "Removed unused sensors:\n- {sensors}"
@@ -216,6 +224,10 @@
         "cleanup_result_empty": {
           "title": "No unused sensors found",
           "description": "No unused sensors were found."
+        },
+        "delete_result": {
+          "title": "All entries deleted",
+          "description": "All sensors and configuration entries have been removed."
         }
       },
       "enum": {
@@ -232,6 +244,7 @@
           "authorize": "Grant admin rights",
           "unauthorize": "Revoke admin rights",
           "cleanup": "Remove unused sensors",
+          "delete": "Delete all entries",
           "finish": "Done",
           "back": "Back"
         }


### PR DESCRIPTION
## Summary
- add new OptionsFlow action to delete all integration entries after confirmation
- localize new delete option in German and English

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689798dbb794832eb934dd41a1192c15