### PR TITLE
Return to options menu after deleting all entries

### DIFF
--- a/custom_components/tally_list/config_flow.py
+++ b/custom_components/tally_list/config_flow.py
@@ -551,7 +551,7 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
         )
 
     async def async_step_delete_result(self, user_input=None):
-        return self.async_abort(reason="delete_all")
+        return await self.async_step_menu()
 
     async def async_step_finish(self, user_input=None):
         return await self._update_drinks()


### PR DESCRIPTION
## Summary
- Return to menu after deleting all Tally entries instead of aborting with a `delete_all` reason

## Testing
- `python -m py_compile custom_components/tally_list/config_flow.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68979ae8ec08832ea7ff7e7cdaf6f2ab