### PR TITLE
chore: bump version to 09.08.2025

### DIFF
--- a/custom_components/tally_list/manifest.json
+++ b/custom_components/tally_list/manifest.json
@@ -3,7 +3,7 @@
   "name": "Tally List",
   "documentation": "https://github.com/Spider19996/ha-tally-list",
   "issue_tracker": "https://github.com/Spider19996/ha-tally-list/issues",
-  "version": "08.08.2025",
+  "version": "09.08.2025",
   "requirements": [],
   "config_flow": true,
   "codeowners": ["@Spider19996"],


### PR DESCRIPTION
## Summary
- bump version to 09.08.2025

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68979c36aa6c832ea2179aebca80090a