### PR TITLE
Close options flow after deleting all entries

### DIFF
--- a/custom_components/tally_list/config_flow.py
+++ b/custom_components/tally_list/config_flow.py
@@ -543,15 +543,12 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
             confirmation = user_input.get("confirm", "").strip().upper()
             if confirmation in {"JA ICH WILL", "YES I WANT"}:
                 await self._delete_all_entries()
-                return self.async_show_form(step_id="delete_result")
+                return self.async_abort(reason="delete_all")
             errors["base"] = "invalid_confirmation"
         schema = vol.Schema({vol.Required("confirm"): str})
         return self.async_show_form(
             step_id="delete", data_schema=schema, errors=errors
         )
-
-    async def async_step_delete_result(self, user_input=None):
-        return self.async_abort(reason="delete_all")
 
     async def async_step_finish(self, user_input=None):
         return await self._update_drinks()

--- a/custom_components/tally_list/translations/de.json
+++ b/custom_components/tally_list/translations/de.json
@@ -105,6 +105,9 @@
   },
   "options": {
       "title": "Strichliste",
+      "abort": {
+        "delete_all": "Alle Sensoren und Konfigurationen wurden entfernt."
+      },
       "error": {
         "invalid_confirmation": "Bitte gib \"JA ICH WILL\" ein."
       },
@@ -224,10 +227,6 @@
         "cleanup_result_empty": {
           "title": "Keine ungenutzten Sensoren gefunden",
           "description": "Es wurden keine ungenutzten Sensoren gefunden."
-        },
-        "delete_result": {
-          "title": "Alle Einträge gelöscht",
-          "description": "Alle Sensoren und Konfigurationen wurden entfernt."
         }
       },
       "enum": {

--- a/custom_components/tally_list/translations/en.json
+++ b/custom_components/tally_list/translations/en.json
@@ -105,6 +105,9 @@
   },
   "options": {
     "title": "Tally List",
+    "abort": {
+      "delete_all": "All sensors and configuration entries have been removed."
+    },
     "error": {
       "invalid_confirmation": "Please type \"YES I WANT\"."
     },
@@ -224,10 +227,6 @@
         "cleanup_result_empty": {
           "title": "No unused sensors found",
           "description": "No unused sensors were found."
-        },
-        "delete_result": {
-          "title": "All entries deleted",
-          "description": "All sensors and configuration entries have been removed."
         }
       },
       "enum": {


### PR DESCRIPTION
## Summary
- Close options flow after removing all Tally entries instead of returning to menu
- Localize the `delete_all` abort message in English and German

## Testing
- `python -m py_compile custom_components/tally_list/config_flow.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68979ae8ec08832ea7ff7e7cdaf6f2ab