### PR TITLE
feat: add free mark support

### DIFF
--- a/custom_components/tally_list/__init__.py
+++ b/custom_components/tally_list/__init__.py
@@ -4,13 +4,15 @@ from __future__ import annotations
 
 import csv
 import os
+import re
 from datetime import datetime, timedelta
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.typing import ConfigType
-from homeassistant.exceptions import Unauthorized
+from homeassistant.exceptions import HomeAssistantError, Unauthorized
 from homeassistant.util.dt import now as dt_now
+from homeassistant.util import dt as dt_util
 
 from .websocket import async_register as async_register_ws
 
@@ -29,6 +31,11 @@ from .const import (
     CONF_OVERRIDE_USERS,
     PRICE_LIST_USERS,
     CONF_CURRENCY,
+    CONF_ENABLE_FREE_MARKS,
+    CONF_CASH_USER_NAME,
+    ATTR_FREE_MARK,
+    ATTR_COMMENT,
+    get_cash_user_name,
 )
 
 PLATFORMS: list[str] = ["sensor", "button"]
@@ -43,6 +50,10 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             CONF_EXCLUDED_USERS: [],
             CONF_OVERRIDE_USERS: [],
             CONF_CURRENCY: "€",
+            CONF_ENABLE_FREE_MARKS: False,
+            CONF_CASH_USER_NAME: get_cash_user_name(hass.config.language),
+            "free_mark_counts": {},
+            "free_marks_ledger": 0.0,
         },
     )
 
@@ -66,6 +77,47 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         if person_name != target_user:
             raise Unauthorized
 
+    def _write_free_mark_log(name: str, drink: str, count: int, comment: str) -> None:
+        tz = dt_util.get_time_zone("Europe/Berlin")
+        ts = dt_util.now(tz).replace(second=0, microsecond=0)
+        base_dir = hass.config.path("backup", "tally_list", "free_marks")
+        os.makedirs(base_dir, exist_ok=True)
+        path = os.path.join(base_dir, f"free_marks_{ts.year}.csv")
+        key_time = ts.strftime("%Y-%m-%dT%H:%M")
+        comment_clean = re.sub(r"[\n\r\t]", " ", comment).strip()[:200]
+        rows: list[list[str]] = []
+        if os.path.exists(path):
+            with open(path, "r", encoding="utf-8", newline="") as csvfile:
+                rows = list(csv.reader(csvfile, delimiter=";"))
+        if not rows:
+            rows = [["Uhrzeit", "Name", "Getränke mit Anzahl", "Kommentar"]]
+        last_key = None
+        if len(rows) > 1:
+            last = rows[-1]
+            last_key = (last[0], last[1], last[3])
+        key = (key_time, name, comment_clean)
+        if key == last_key:
+            drink_map: dict[str, int] = {}
+            if rows[-1][2]:
+                for part in rows[-1][2].split(","):
+                    part = part.strip()
+                    if not part:
+                        continue
+                    dname, dcount = part.rsplit(" x", 1)
+                    drink_map[dname] = int(dcount)
+            drink_map[drink] = drink_map.get(drink, 0) + count
+            drink_map = {k: v for k, v in drink_map.items() if v != 0}
+            drink_str = ", ".join(
+                f"{k} x{v}" for k, v in sorted(drink_map.items())
+            )
+            rows[-1][2] = drink_str
+        else:
+            drink_str = f"{drink} x{count}"
+            rows.append([key_time, name, drink_str, comment_clean])
+        with open(path, "w", encoding="utf-8", newline="") as csvfile:
+            writer = csv.writer(csvfile, delimiter=";", quoting=csv.QUOTE_MINIMAL)
+            writer.writerows(rows)
+
     async def adjust_count_service(call):
         user = call.data[ATTR_USER]
         await _verify_permissions(call, user)
@@ -86,6 +138,41 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         await _verify_permissions(call, user)
         drink = call.data[ATTR_DRINK]
         count = max(0, call.data.get("count", 1))
+        free_mark = call.data.get(ATTR_FREE_MARK, False)
+        comment = call.data.get(ATTR_COMMENT, "")
+        if free_mark:
+            if not hass.data[DOMAIN].get(CONF_ENABLE_FREE_MARKS):
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN,
+                    translation_key="free_marks_disabled",
+                )
+            if not hass.data[DOMAIN].get(CONF_CASH_USER_NAME):
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN, translation_key="cash_user_missing"
+                )
+            comment = comment.strip()
+            if len(comment) < 3 or len(comment) > 200:
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN, translation_key="comment_required"
+                )
+            if drink not in hass.data[DOMAIN].get("drinks", {}):
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN, translation_key="drink_unknown"
+                )
+            counts = hass.data[DOMAIN].setdefault("free_mark_counts", {})
+            counts[drink] = counts.get(drink, 0) + count
+            price = hass.data[DOMAIN]["drinks"].get(drink, 0.0)
+            hass.data[DOMAIN]["free_marks_ledger"] = hass.data[DOMAIN].get(
+                "free_marks_ledger", 0.0
+            ) + price * count
+            await hass.async_add_executor_job(
+                _write_free_mark_log, user, drink, count, comment
+            )
+            hass.bus.async_fire(
+                "tally_list_free_mark_created",
+                {"user": user, "drink": drink, "count": count, "comment": comment},
+            )
+            return
         for entry_id, data in hass.data[DOMAIN].items():
             if not isinstance(data, dict) or "entry" not in data:
                 continue
@@ -102,6 +189,37 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         await _verify_permissions(call, user)
         drink = call.data[ATTR_DRINK]
         count = max(0, call.data.get("count", 1))
+        free_mark = call.data.get(ATTR_FREE_MARK, False)
+        comment = call.data.get(ATTR_COMMENT, "")
+        if free_mark:
+            if not hass.data[DOMAIN].get(CONF_ENABLE_FREE_MARKS):
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN,
+                    translation_key="free_marks_disabled",
+                )
+            if not hass.data[DOMAIN].get(CONF_CASH_USER_NAME):
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN, translation_key="cash_user_missing"
+                )
+            counts = hass.data[DOMAIN].setdefault("free_mark_counts", {})
+            if drink not in counts or counts[drink] < count:
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN, translation_key="cannot_remove_count"
+                )
+            counts[drink] -= count
+            price = hass.data[DOMAIN]["drinks"].get(drink, 0.0)
+            hass.data[DOMAIN]["free_marks_ledger"] = hass.data[DOMAIN].get(
+                "free_marks_ledger", 0.0
+            ) - price * count
+            comment = comment.strip()
+            await hass.async_add_executor_job(
+                _write_free_mark_log, user, drink, -count, comment
+            )
+            hass.bus.async_fire(
+                "tally_list_free_mark_reversed",
+                {"user": user, "drink": drink, "count": count, "comment": comment},
+            )
+            return
         for entry_id, data in hass.data[DOMAIN].items():
             if not isinstance(data, dict) or "entry" not in data:
                 continue
@@ -377,6 +495,44 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             CONF_EXCLUDED_USERS: hass.data[DOMAIN].get("excluded_users", []),
             CONF_OVERRIDE_USERS: hass.data[DOMAIN].get("override_users", []),
             CONF_CURRENCY: hass.data[DOMAIN][CONF_CURRENCY],
+            CONF_ENABLE_FREE_MARKS: hass.data[DOMAIN].get(CONF_ENABLE_FREE_MARKS, False),
+            CONF_CASH_USER_NAME: hass.data[DOMAIN].get(
+                CONF_CASH_USER_NAME, get_cash_user_name(hass.config.language)
+            ),
+        }
+        if "drinks" in hass.data[DOMAIN]:
+            entry_data["drinks"] = hass.data[DOMAIN]["drinks"]
+        hass.config_entries.async_update_entry(entry, data=entry_data)
+    if (
+        not hass.data[DOMAIN].get(CONF_ENABLE_FREE_MARKS)
+        and entry.data.get(CONF_ENABLE_FREE_MARKS) is not None
+    ):
+        hass.data[DOMAIN][CONF_ENABLE_FREE_MARKS] = entry.data[CONF_ENABLE_FREE_MARKS]
+    if (
+        not hass.data[DOMAIN].get(CONF_CASH_USER_NAME)
+        and entry.data.get(CONF_CASH_USER_NAME) is not None
+    ):
+        hass.data[DOMAIN][CONF_CASH_USER_NAME] = entry.data[CONF_CASH_USER_NAME]
+    if (
+        (hass.data[DOMAIN].get(CONF_ENABLE_FREE_MARKS) is not None
+         and CONF_ENABLE_FREE_MARKS not in entry.data)
+        or (
+            hass.data[DOMAIN].get(CONF_CASH_USER_NAME) is not None
+            and CONF_CASH_USER_NAME not in entry.data
+        )
+    ):
+        entry_data = {
+            "user": entry.data.get("user"),
+            CONF_FREE_AMOUNT: hass.data[DOMAIN].get("free_amount", 0.0),
+            CONF_EXCLUDED_USERS: hass.data[DOMAIN].get("excluded_users", []),
+            CONF_OVERRIDE_USERS: hass.data[DOMAIN].get("override_users", []),
+            CONF_CURRENCY: hass.data[DOMAIN].get(CONF_CURRENCY, "€"),
+            CONF_ENABLE_FREE_MARKS: hass.data[DOMAIN].get(
+                CONF_ENABLE_FREE_MARKS, False
+            ),
+            CONF_CASH_USER_NAME: hass.data[DOMAIN].get(
+                CONF_CASH_USER_NAME, get_cash_user_name(hass.config.language)
+            ),
         }
         if "drinks" in hass.data[DOMAIN]:
             entry_data["drinks"] = hass.data[DOMAIN]["drinks"]
@@ -399,6 +555,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             # user is re-added later
             hass.data[DOMAIN].pop(CONF_OVERRIDE_USERS, None)
             hass.data[DOMAIN].pop(CONF_CURRENCY, None)
+            hass.data[DOMAIN].pop(CONF_ENABLE_FREE_MARKS, None)
+            hass.data[DOMAIN].pop(CONF_CASH_USER_NAME, None)
+            hass.data[DOMAIN].pop("free_mark_counts", None)
+            hass.data[DOMAIN].pop("free_marks_ledger", None)
         if not any(
             isinstance(value, dict) and "entry" in value
             for value in hass.data.get(DOMAIN, {}).values()

--- a/custom_components/tally_list/config_flow.py
+++ b/custom_components/tally_list/config_flow.py
@@ -22,6 +22,9 @@ from .const import (
     PRICE_LIST_USERS,
     get_price_list_user,
     CONF_CURRENCY,
+    CONF_ENABLE_FREE_MARKS,
+    CONF_CASH_USER_NAME,
+    get_cash_user_name,
 )
 
 
@@ -167,6 +170,46 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return await self.async_step_menu()
         schema = vol.Schema({vol.Required(CONF_CURRENCY, default=self._currency): str})
         return self.async_show_form(step_id="currency", data_schema=schema)
+
+    async def async_step_free_marks(self, user_input=None):
+        if user_input is not None:
+            enable = user_input[CONF_ENABLE_FREE_MARKS]
+            name = user_input.get(CONF_CASH_USER_NAME, self._cash_user_name)
+            name = name.strip()
+            if self._enable_free_marks and not enable:
+                self._cash_user_name = name
+                return await self.async_step_free_marks_confirm()
+            self._enable_free_marks = enable
+            self._cash_user_name = name
+            return await self.async_step_menu()
+        schema = vol.Schema(
+            {
+                vol.Required(
+                    CONF_ENABLE_FREE_MARKS, default=self._enable_free_marks
+                ): bool,
+                vol.Optional(
+                    CONF_CASH_USER_NAME, default=self._cash_user_name
+                ): str,
+            }
+        )
+        return self.async_show_form(
+            step_id="free_marks",
+            data_schema=schema,
+        )
+
+    async def async_step_free_marks_confirm(self, user_input=None):
+        errors = {}
+        if user_input is not None:
+            confirmation = user_input.get("confirm", "").strip().upper()
+            if confirmation in {"JA ICH WILL", "YES I WANT"}:
+                self._enable_free_marks = False
+                self.hass.data.get(DOMAIN, {}).get("free_mark_counts", {}).clear()
+                return await self.async_step_menu()
+            errors["base"] = "confirmation_required"
+        schema = vol.Schema({vol.Required("confirm"): str})
+        return self.async_show_form(
+            step_id="free_marks_confirm", data_schema=schema, errors=errors
+        )
 
     async def async_step_exclude(self, user_input=None):
         return await self.async_step_add_excluded_user(user_input)
@@ -370,6 +413,8 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self.hass.data[DOMAIN][CONF_EXCLUDED_USERS] = self._excluded_users
         self.hass.data[DOMAIN][CONF_OVERRIDE_USERS] = self._override_users
         self.hass.data[DOMAIN][CONF_CURRENCY] = self._currency
+        self.hass.data[DOMAIN][CONF_ENABLE_FREE_MARKS] = self._enable_free_marks
+        self.hass.data[DOMAIN][CONF_CASH_USER_NAME] = self._cash_user_name
         if self._create_price_user:
             self.hass.async_create_task(
                 self.hass.config_entries.flow.async_init(
@@ -427,6 +472,8 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
         self._excluded_users: list[str] = []
         self._override_users: list[str] = []
         self._currency: str = "€"
+        self._enable_free_marks: bool = False
+        self._cash_user_name: str = get_cash_user_name(None)
 
     async def async_step_init(self, user_input=None):
         self._drinks = self.hass.data.get(DOMAIN, {}).get("drinks", {}).copy()
@@ -438,6 +485,12 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
             self.hass.data.get(DOMAIN, {}).get(CONF_OVERRIDE_USERS, [])
         ).copy()
         self._currency = self.hass.data.get(DOMAIN, {}).get(CONF_CURRENCY, "€")
+        self._enable_free_marks = self.hass.data.get(DOMAIN, {}).get(
+            CONF_ENABLE_FREE_MARKS, False
+        )
+        self._cash_user_name = self.hass.data.get(DOMAIN, {}).get(
+            CONF_CASH_USER_NAME, get_cash_user_name(self.hass.config.language)
+        )
         return await self.async_step_menu()
 
     async def async_step_menu(self, user_input=None):
@@ -446,6 +499,7 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
             menu_options=[
                 "user",
                 "drinks",
+                "free_marks",
                 "cleanup",
                 "delete",
                 "finish",
@@ -847,6 +901,8 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
                 CONF_EXCLUDED_USERS: self._excluded_users,
                 CONF_OVERRIDE_USERS: self._override_users,
                 CONF_CURRENCY: self._currency,
+                CONF_ENABLE_FREE_MARKS: self._enable_free_marks,
+                CONF_CASH_USER_NAME: self._cash_user_name,
             }
             self.hass.config_entries.async_update_entry(entry, data=data)
             await self.hass.config_entries.async_reload(entry.entry_id)
@@ -862,5 +918,7 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
                 CONF_EXCLUDED_USERS: self._excluded_users,
                 CONF_OVERRIDE_USERS: self._override_users,
                 CONF_CURRENCY: self._currency,
+                CONF_ENABLE_FREE_MARKS: self._enable_free_marks,
+                CONF_CASH_USER_NAME: self._cash_user_name,
             },
         )

--- a/custom_components/tally_list/const.py
+++ b/custom_components/tally_list/const.py
@@ -9,8 +9,13 @@ CONF_EXCLUDED_USERS = "excluded_users"
 CONF_OVERRIDE_USERS = "override_users"
 CONF_CURRENCY = "currency"
 
+CONF_ENABLE_FREE_MARKS = "enable_free_marks"
+CONF_CASH_USER_NAME = "cash_user_name"
+
 ATTR_USER = "user"
 ATTR_DRINK = "drink"
+ATTR_FREE_MARK = "free_mark"
+ATTR_COMMENT = "comment"
 
 SERVICE_ADD_DRINK = "add_drink"
 SERVICE_REMOVE_DRINK = "remove_drink"
@@ -24,6 +29,16 @@ PRICE_LIST_USER_EN = "Price list"
 # Default name for backward compatibility
 PRICE_LIST_USER = PRICE_LIST_USER_DE
 PRICE_LIST_USERS = {PRICE_LIST_USER_DE, PRICE_LIST_USER_EN}
+
+CASH_USER_DE = "Freigetränke"
+CASH_USER_EN = "Free Drinks"
+
+
+def get_cash_user_name(language: str | None) -> str:
+    """Return localized cash user name."""
+    if language and language.lower().startswith("de"):
+        return CASH_USER_DE
+    return CASH_USER_EN
 
 
 def get_price_list_user(language: str | None) -> str:

--- a/custom_components/tally_list/services.yaml
+++ b/custom_components/tally_list/services.yaml
@@ -22,6 +22,16 @@ add_drink:
         number:
           min: 1
           step: 1
+    free_mark:
+      description: Book as free mark
+      required: false
+      selector:
+        boolean:
+    comment:
+      description: Comment for free mark
+      required: false
+      selector:
+        text:
 remove_drink:
   name: Remove drink
   description: Decrement drink counter for a person
@@ -46,6 +56,16 @@ remove_drink:
         number:
           min: 1
           step: 1
+    free_mark:
+      description: Book as free mark
+      required: false
+      selector:
+        boolean:
+    comment:
+      description: Comment for free mark
+      required: false
+      selector:
+        text:
 adjust_count:
   name: Adjust count
   description: Set drink count for a person

--- a/custom_components/tally_list/translations/de.json
+++ b/custom_components/tally_list/translations/de.json
@@ -109,7 +109,8 @@
         "delete_all": "Alle Sensoren und Konfigurationen wurden entfernt."
       },
       "error": {
-        "invalid_confirmation": "Bitte gib \"JA ICH WILL\" ein."
+        "invalid_confirmation": "Bitte gib \"JA ICH WILL\" ein.",
+        "confirmation_required": "Bestätigung erforderlich"
       },
       "step": {
         "menu": {
@@ -117,6 +118,7 @@
           "menu_options": {
             "user": "Nutzereinstellungen",
             "drinks": "Getränkeeinstellungen",
+            "free_marks": "Freimarken",
             "cleanup": "Nicht mehr genutzte Sensoren entfernen",
             "delete": "Alle Einträge löschen",
             "finish": "Fertig"
@@ -141,6 +143,21 @@
             "edit": "Bearbeiten",
             "currency": "Währung setzen",
             "back": "Zurück"
+          }
+        },
+        "free_marks": {
+          "title": "Freimarken",
+          "description": "Freimarken werden auf den Freigetränke-Nutzer gebucht, nicht auf normale Nutzer.",
+          "data": {
+            "enable_free_marks": "Freimarken aktivieren",
+            "cash_user_name": "Name des Freigetränke-Nutzers"
+          }
+        },
+        "free_marks_confirm": {
+          "title": "Freimarken deaktivieren",
+          "description": "Gib zur Bestätigung \"JA ICH WILL\" ein",
+          "data": {
+            "confirm": "Bestätigung"
           }
         },
         "add_drink": {
@@ -233,6 +250,7 @@
         "action": {
           "user": "Nutzereinstellungen",
           "drinks": "Getränkeeinstellungen",
+          "free_marks": "Freimarken",
           "add": "Hinzufügen",
           "remove": "Entfernen",
           "edit": "Bearbeiten",
@@ -249,6 +267,13 @@
         }
       }
     },
+  "exceptions": {
+    "free_marks_disabled": "Freimarken sind deaktiviert",
+    "comment_required": "Kommentar erforderlich",
+    "cash_user_missing": "Freigetränke-Nutzer fehlt",
+    "drink_unknown": "Unbekanntes Getränk",
+    "cannot_remove_count": "Anzahl kann nicht entfernt werden"
+  },
   "services": {
     "add_drink": {
       "name": "Getränk hinzufügen",
@@ -265,6 +290,14 @@
         "count": {
           "name": "Anzahl",
           "description": "Anzahl der hinzuzufügenden Getränke"
+        },
+        "free_mark": {
+          "name": "Freimarke",
+          "description": "Als Freimarke buchen"
+        },
+        "comment": {
+          "name": "Kommentar",
+          "description": "Kommentar für Freimarke"
         }
       }
     },
@@ -283,6 +316,14 @@
         "count": {
           "name": "Anzahl",
           "description": "Anzahl der zu entfernenden Getränke"
+        },
+        "free_mark": {
+          "name": "Freimarke",
+          "description": "Als Freimarke buchen"
+        },
+        "comment": {
+          "name": "Kommentar",
+          "description": "Kommentar für Freimarke"
         }
       }
     },

--- a/custom_components/tally_list/translations/en.json
+++ b/custom_components/tally_list/translations/en.json
@@ -109,7 +109,8 @@
       "delete_all": "All sensors and configuration entries have been removed."
     },
     "error": {
-      "invalid_confirmation": "Please type \"YES I WANT\"."
+      "invalid_confirmation": "Please type \"YES I WANT\".",
+      "confirmation_required": "Confirmation required"
     },
     "step": {
         "menu": {
@@ -117,6 +118,7 @@
           "menu_options": {
             "user": "User settings",
             "drinks": "Drink settings",
+            "free_marks": "Free marks",
             "cleanup": "Remove unused sensors",
             "delete": "Delete all entries",
             "finish": "Done"
@@ -141,6 +143,21 @@
             "edit": "Edit price",
             "currency": "Set currency",
             "back": "Back"
+          }
+        },
+        "free_marks": {
+          "title": "Free marks",
+          "description": "Free marks are booked to the free drinks user, not to regular users.",
+          "data": {
+            "enable_free_marks": "Enable free marks",
+            "cash_user_name": "Free drinks user name"
+          }
+        },
+        "free_marks_confirm": {
+          "title": "Disable free marks",
+          "description": "Type \"YES I WANT\" to confirm",
+          "data": {
+            "confirm": "Confirmation"
           }
         },
         "add_drink": {
@@ -233,6 +250,7 @@
         "action": {
           "user": "User settings",
           "drinks": "Drink settings",
+          "free_marks": "Free marks",
           "add": "Add drink",
           "remove": "Remove drink",
           "edit": "Edit price",
@@ -248,6 +266,13 @@
           "back": "Back"
         }
       }
+  },
+  "exceptions": {
+    "free_marks_disabled": "Free marks feature is disabled",
+    "comment_required": "Comment required",
+    "cash_user_missing": "Free drinks user missing",
+    "drink_unknown": "Unknown drink",
+    "cannot_remove_count": "Cannot remove count"
   },
   "services": {
     "add_drink": {
@@ -265,6 +290,14 @@
         "count": {
           "name": "Count",
           "description": "Number of drinks to add"
+        },
+        "free_mark": {
+          "name": "Free mark",
+          "description": "Book as free mark"
+        },
+        "comment": {
+          "name": "Comment",
+          "description": "Comment for free mark"
         }
       }
     },
@@ -283,6 +316,14 @@
         "count": {
           "name": "Count",
           "description": "Number of drinks to remove"
+        },
+        "free_mark": {
+          "name": "Free mark",
+          "description": "Book as free mark"
+        },
+        "comment": {
+          "name": "Comment",
+          "description": "Comment for free mark"
         }
       }
     },


### PR DESCRIPTION
## Summary
- support booking drinks as free marks with CSV logging
- add configuration option to enable free marks and manage cash user
- extend services and translations for free mark usage

## Testing
- `python -m py_compile custom_components/tally_list/const.py custom_components/tally_list/__init__.py custom_components/tally_list/config_flow.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689847002358832e9403098da8066754