### PR TITLE
Add free marks support

### DIFF
--- a/custom_components/tally_list/__init__.py
+++ b/custom_components/tally_list/__init__.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.typing import ConfigType
-from homeassistant.exceptions import Unauthorized
+from homeassistant.exceptions import Unauthorized, HomeAssistantError
 from homeassistant.util.dt import now as dt_now
 
 from .websocket import async_register as async_register_ws
@@ -29,6 +29,16 @@ from .const import (
     CONF_OVERRIDE_USERS,
     PRICE_LIST_USERS,
     CONF_CURRENCY,
+    CONF_ENABLE_FREE_MARKS,
+    CONF_CASH_USER_NAME,
+    EVENT_FREE_MARK_CREATED,
+    EVENT_FREE_MARK_REVERSED,
+    ERROR_FREE_MARKS_DISABLED,
+    ERROR_COMMENT_REQUIRED,
+    ERROR_CASH_USER_MISSING,
+    ERROR_CANNOT_REMOVE_COUNT,
+    ERROR_DRINK_UNKNOWN,
+    get_cash_user_name,
 )
 
 PLATFORMS: list[str] = ["sensor", "button"]
@@ -43,8 +53,12 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             CONF_EXCLUDED_USERS: [],
             CONF_OVERRIDE_USERS: [],
             CONF_CURRENCY: "€",
+            CONF_ENABLE_FREE_MARKS: False,
+            CONF_CASH_USER_NAME: get_cash_user_name(hass.config.language),
         },
     )
+    hass.data[DOMAIN].setdefault("free_ledger", {})
+    hass.data[DOMAIN].setdefault("free_ledger_total", 0.0)
 
     async def _verify_permissions(call, target_user: str | None) -> None:
         user_id = call.context.user_id
@@ -86,6 +100,38 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         await _verify_permissions(call, user)
         drink = call.data[ATTR_DRINK]
         count = max(0, call.data.get("count", 1))
+        if call.data.get("free_mark"):
+            if not hass.data[DOMAIN].get(CONF_ENABLE_FREE_MARKS):
+                raise HomeAssistantError(ERROR_FREE_MARKS_DISABLED)
+            comment = call.data.get("comment", "").strip()
+            if len(comment) < 3 or len(comment) > 200:
+                raise HomeAssistantError(ERROR_COMMENT_REQUIRED)
+            cash_user = hass.data[DOMAIN].get("cash_user")
+            if not cash_user:
+                raise HomeAssistantError(ERROR_CASH_USER_MISSING)
+            price = hass.data[DOMAIN].get("drinks", {}).get(drink)
+            if price is None:
+                raise HomeAssistantError(ERROR_DRINK_UNKNOWN)
+            ledger = hass.data[DOMAIN].setdefault("free_ledger", {})
+            drink_ledger = ledger.setdefault(drink, [])
+            drink_ledger.append({"price": price, "count": count})
+            hass.data[DOMAIN]["free_ledger_total"] = (
+                hass.data[DOMAIN].get("free_ledger_total", 0.0)
+                + price * count
+            )
+            counts = cash_user.setdefault("counts", {})
+            counts[drink] = counts.get(drink, 0) + count
+            hass.bus.async_fire(
+                EVENT_FREE_MARK_CREATED,
+                {
+                    ATTR_USER: user,
+                    ATTR_DRINK: drink,
+                    "count": count,
+                    "comment": comment,
+                    "price": price,
+                },
+            )
+            return
         for entry_id, data in hass.data[DOMAIN].items():
             if not isinstance(data, dict) or "entry" not in data:
                 continue
@@ -102,6 +148,44 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         await _verify_permissions(call, user)
         drink = call.data[ATTR_DRINK]
         count = max(0, call.data.get("count", 1))
+        if call.data.get("free_mark"):
+            if not hass.data[DOMAIN].get(CONF_ENABLE_FREE_MARKS):
+                raise HomeAssistantError(ERROR_FREE_MARKS_DISABLED)
+            cash_user = hass.data[DOMAIN].get("cash_user")
+            if not cash_user:
+                raise HomeAssistantError(ERROR_CASH_USER_MISSING)
+            price = hass.data[DOMAIN].get("drinks", {}).get(drink)
+            if price is None:
+                raise HomeAssistantError(ERROR_DRINK_UNKNOWN)
+            ledger = hass.data[DOMAIN].setdefault("free_ledger", {})
+            drink_ledger = ledger.get(drink, [])
+            remaining = count
+            refund = 0.0
+            while drink_ledger and remaining > 0:
+                entry = drink_ledger[0]
+                if entry["count"] > remaining:
+                    entry["count"] -= remaining
+                    refund += entry["price"] * remaining
+                    remaining = 0
+                else:
+                    refund += entry["price"] * entry["count"]
+                    remaining -= entry["count"]
+                    drink_ledger.pop(0)
+            if remaining > 0:
+                raise HomeAssistantError(ERROR_CANNOT_REMOVE_COUNT)
+            counts = cash_user.setdefault("counts", {})
+            current = counts.get(drink, 0)
+            if current < count:
+                raise HomeAssistantError(ERROR_CANNOT_REMOVE_COUNT)
+            counts[drink] = current - count
+            hass.data[DOMAIN]["free_ledger_total"] = (
+                hass.data[DOMAIN].get("free_ledger_total", 0.0) - refund
+            )
+            hass.bus.async_fire(
+                EVENT_FREE_MARK_REVERSED,
+                {ATTR_USER: user, ATTR_DRINK: drink, "count": count, "price": price},
+            )
+            return
         for entry_id, data in hass.data[DOMAIN].items():
             if not isinstance(data, dict) or "entry" not in data:
                 continue
@@ -381,6 +465,43 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if "drinks" in hass.data[DOMAIN]:
             entry_data["drinks"] = hass.data[DOMAIN]["drinks"]
         hass.config_entries.async_update_entry(entry, data=entry_data)
+    if (
+        not hass.data[DOMAIN].get(CONF_ENABLE_FREE_MARKS)
+        and entry.data.get(CONF_ENABLE_FREE_MARKS) is not None
+    ):
+        hass.data[DOMAIN][CONF_ENABLE_FREE_MARKS] = entry.data[
+            CONF_ENABLE_FREE_MARKS
+        ]
+    if (
+        hass.data[DOMAIN].get(CONF_ENABLE_FREE_MARKS) is not None
+        and CONF_ENABLE_FREE_MARKS not in entry.data
+    ):
+        entry_data = {
+            "user": entry.data.get("user"),
+            CONF_FREE_AMOUNT: hass.data[DOMAIN].get("free_amount", 0.0),
+            CONF_EXCLUDED_USERS: hass.data[DOMAIN].get("excluded_users", []),
+            CONF_OVERRIDE_USERS: hass.data[DOMAIN].get("override_users", []),
+            CONF_CURRENCY: hass.data[DOMAIN].get(CONF_CURRENCY, "€"),
+            CONF_ENABLE_FREE_MARKS: hass.data[DOMAIN].get(
+                CONF_ENABLE_FREE_MARKS, False
+            ),
+            CONF_CASH_USER_NAME: hass.data[DOMAIN].get(
+                CONF_CASH_USER_NAME, get_cash_user_name(hass.config.language)
+            ),
+        }
+        if "drinks" in hass.data[DOMAIN]:
+            entry_data["drinks"] = hass.data[DOMAIN]["drinks"]
+        hass.config_entries.async_update_entry(entry, data=entry_data)
+    if (
+        not hass.data[DOMAIN].get(CONF_CASH_USER_NAME)
+        and entry.data.get(CONF_CASH_USER_NAME) is not None
+    ):
+        hass.data[DOMAIN][CONF_CASH_USER_NAME] = entry.data[CONF_CASH_USER_NAME]
+    if hass.data[DOMAIN].get(CONF_ENABLE_FREE_MARKS):
+        hass.data[DOMAIN].setdefault(
+            "cash_user",
+            {"name": hass.data[DOMAIN][CONF_CASH_USER_NAME], "counts": {}},
+        )
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 

--- a/custom_components/tally_list/config_flow.py
+++ b/custom_components/tally_list/config_flow.py
@@ -22,6 +22,9 @@ from .const import (
     PRICE_LIST_USERS,
     get_price_list_user,
     CONF_CURRENCY,
+    CONF_ENABLE_FREE_MARKS,
+    CONF_CASH_USER_NAME,
+    get_cash_user_name,
 )
 
 
@@ -179,6 +182,51 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_unauthorize(self, user_input=None):
         return await self.async_step_remove_override_user(user_input)
+
+    async def async_step_free_marks(self, user_input=None):
+        if user_input is not None:
+            enable = user_input.get(CONF_ENABLE_FREE_MARKS, False)
+            name = user_input.get(CONF_CASH_USER_NAME, "").strip()
+            if name:
+                self._cash_user_name = name
+            if enable:
+                self._enable_free_marks = True
+                domain = self.hass.data.setdefault(DOMAIN, {})
+                domain["cash_user"] = {"name": self._cash_user_name, "counts": {}}
+                domain.setdefault("free_ledger", {})
+                domain.setdefault("free_ledger_total", 0.0)
+                return await self._update_drinks()
+            if self._enable_free_marks:
+                return await self.async_step_disable_free_marks()
+            self._enable_free_marks = False
+            return await self._update_drinks()
+        schema = vol.Schema(
+            {
+                vol.Required(
+                    CONF_ENABLE_FREE_MARKS, default=self._enable_free_marks
+                ): bool,
+                vol.Optional(
+                    CONF_CASH_USER_NAME, default=self._cash_user_name
+                ): str,
+            }
+        )
+        return self.async_show_form(step_id="free_marks", data_schema=schema)
+
+    async def async_step_disable_free_marks(self, user_input=None):
+        errors = {}
+        if user_input is not None:
+            confirmation = user_input.get("confirm", "").strip().upper()
+            if confirmation in {"JA ICH WILL", "YES I WANT"}:
+                self._enable_free_marks = False
+                domain = self.hass.data.setdefault(DOMAIN, {})
+                domain.pop("cash_user", None)
+                domain.pop("free_ledger", None)
+                return await self._update_drinks()
+            errors["base"] = "invalid_confirmation"
+        schema = vol.Schema({vol.Required("confirm"): str})
+        return self.async_show_form(
+            step_id="disable_free_marks", data_schema=schema, errors=errors
+        )
 
     async def async_step_add_drink(self, user_input=None):
         if user_input is not None:
@@ -370,6 +418,8 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self.hass.data[DOMAIN][CONF_EXCLUDED_USERS] = self._excluded_users
         self.hass.data[DOMAIN][CONF_OVERRIDE_USERS] = self._override_users
         self.hass.data[DOMAIN][CONF_CURRENCY] = self._currency
+        self.hass.data[DOMAIN][CONF_ENABLE_FREE_MARKS] = self._enable_free_marks
+        self.hass.data[DOMAIN][CONF_CASH_USER_NAME] = self._cash_user_name
         if self._create_price_user:
             self.hass.async_create_task(
                 self.hass.config_entries.flow.async_init(
@@ -427,6 +477,8 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
         self._excluded_users: list[str] = []
         self._override_users: list[str] = []
         self._currency: str = "€"
+        self._enable_free_marks: bool = False
+        self._cash_user_name: str = get_cash_user_name(None)
 
     async def async_step_init(self, user_input=None):
         self._drinks = self.hass.data.get(DOMAIN, {}).get("drinks", {}).copy()
@@ -438,6 +490,12 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
             self.hass.data.get(DOMAIN, {}).get(CONF_OVERRIDE_USERS, [])
         ).copy()
         self._currency = self.hass.data.get(DOMAIN, {}).get(CONF_CURRENCY, "€")
+        self._enable_free_marks = self.hass.data.get(DOMAIN, {}).get(
+            CONF_ENABLE_FREE_MARKS, False
+        )
+        self._cash_user_name = self.hass.data.get(DOMAIN, {}).get(
+            CONF_CASH_USER_NAME, get_cash_user_name(self.hass.config.language)
+        )
         return await self.async_step_menu()
 
     async def async_step_menu(self, user_input=None):
@@ -446,6 +504,7 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
             menu_options=[
                 "user",
                 "drinks",
+                "free_marks",
                 "cleanup",
                 "delete",
                 "finish",
@@ -847,6 +906,8 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
                 CONF_EXCLUDED_USERS: self._excluded_users,
                 CONF_OVERRIDE_USERS: self._override_users,
                 CONF_CURRENCY: self._currency,
+                CONF_ENABLE_FREE_MARKS: self._enable_free_marks,
+                CONF_CASH_USER_NAME: self._cash_user_name,
             }
             self.hass.config_entries.async_update_entry(entry, data=data)
             await self.hass.config_entries.async_reload(entry.entry_id)
@@ -862,5 +923,7 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
                 CONF_EXCLUDED_USERS: self._excluded_users,
                 CONF_OVERRIDE_USERS: self._override_users,
                 CONF_CURRENCY: self._currency,
+                CONF_ENABLE_FREE_MARKS: self._enable_free_marks,
+                CONF_CASH_USER_NAME: self._cash_user_name,
             },
         )

--- a/custom_components/tally_list/const.py
+++ b/custom_components/tally_list/const.py
@@ -8,6 +8,9 @@ CONF_FREE_AMOUNT = "free_amount"
 CONF_EXCLUDED_USERS = "excluded_users"
 CONF_OVERRIDE_USERS = "override_users"
 CONF_CURRENCY = "currency"
+CONF_ENABLE_FREE_MARKS = "enable_free_marks"
+CONF_CASH_USER_NAME = "cash_user_name"
+CONF_IS_SYSTEM = "is_system"
 
 ATTR_USER = "user"
 ATTR_DRINK = "drink"
@@ -18,6 +21,9 @@ SERVICE_ADJUST_COUNT = "adjust_count"
 SERVICE_RESET_COUNTERS = "reset_counters"
 SERVICE_EXPORT_CSV = "export_csv"
 
+EVENT_FREE_MARK_CREATED = "tally_list_free_mark_created"
+EVENT_FREE_MARK_REVERSED = "tally_list_free_mark_reversed"
+
 # Dedicated user name that exposes drink prices
 PRICE_LIST_USER_DE = "Preisliste"
 PRICE_LIST_USER_EN = "Price list"
@@ -25,9 +31,26 @@ PRICE_LIST_USER_EN = "Price list"
 PRICE_LIST_USER = PRICE_LIST_USER_DE
 PRICE_LIST_USERS = {PRICE_LIST_USER_DE, PRICE_LIST_USER_EN}
 
+CASH_USER_DE = "Freigetränke"
+CASH_USER_EN = "Free Drinks"
+
+ERROR_FREE_MARKS_DISABLED = "FREE_MARKS_DISABLED"
+ERROR_COMMENT_REQUIRED = "COMMENT_REQUIRED"
+ERROR_CASH_USER_MISSING = "CASH_USER_MISSING"
+ERROR_CANNOT_REMOVE_COUNT = "CANNOT_REMOVE_COUNT"
+ERROR_CONFIRMATION_REQUIRED = "CONFIRMATION_REQUIRED"
+ERROR_DRINK_UNKNOWN = "DRINK_UNKNOWN"
+
 
 def get_price_list_user(language: str | None) -> str:
     """Return localized price list user name."""
     if language and language.lower().startswith("de"):
         return PRICE_LIST_USER_DE
     return PRICE_LIST_USER_EN
+
+
+def get_cash_user_name(language: str | None) -> str:
+    """Return localized cash user name."""
+    if language and language.lower().startswith("de"):
+        return CASH_USER_DE
+    return CASH_USER_EN

--- a/custom_components/tally_list/services.yaml
+++ b/custom_components/tally_list/services.yaml
@@ -22,6 +22,17 @@ add_drink:
         number:
           min: 1
           step: 1
+    free_mark:
+      description: Book as free mark
+      required: false
+      selector:
+        boolean:
+    comment:
+      description: Reason for free mark
+      required: false
+      example: Birthday
+      selector:
+        text:
 remove_drink:
   name: Remove drink
   description: Decrement drink counter for a person
@@ -46,6 +57,16 @@ remove_drink:
         number:
           min: 1
           step: 1
+    free_mark:
+      description: Remove free mark
+      required: false
+      selector:
+        boolean:
+    comment:
+      description: Reason for free mark
+      required: false
+      selector:
+        text:
 adjust_count:
   name: Adjust count
   description: Set drink count for a person

--- a/custom_components/tally_list/translations/de.json
+++ b/custom_components/tally_list/translations/de.json
@@ -117,6 +117,7 @@
           "menu_options": {
             "user": "Nutzereinstellungen",
             "drinks": "Getränkeeinstellungen",
+            "free_marks": "Freigetränke Einstellungen",
             "cleanup": "Nicht mehr genutzte Sensoren entfernen",
             "delete": "Alle Einträge löschen",
             "finish": "Fertig"
@@ -141,6 +142,20 @@
             "edit": "Bearbeiten",
             "currency": "Währung setzen",
             "back": "Zurück"
+          }
+        },
+        "free_marks": {
+          "title": "Freigetränke Einstellungen",
+          "data": {
+            "enable_free_marks": "Freigetränke aktivieren",
+            "cash_user_name": "Name für Freigetränke"
+          }
+        },
+        "disable_free_marks": {
+          "title": "Freigetränke deaktivieren",
+          "description": "Hierdurch wird der System-Benutzer und alle seine Striche gelöscht. Zum Bestätigen \"JA ICH WILL\" eingeben.",
+          "data": {
+            "confirm": "Bestätigung"
           }
         },
         "add_drink": {
@@ -233,6 +248,7 @@
         "action": {
           "user": "Nutzereinstellungen",
           "drinks": "Getränkeeinstellungen",
+          "free_marks": "Freigetränke Einstellungen",
           "add": "Hinzufügen",
           "remove": "Entfernen",
           "edit": "Bearbeiten",
@@ -265,6 +281,14 @@
         "count": {
           "name": "Anzahl",
           "description": "Anzahl der hinzuzufügenden Getränke"
+        },
+        "free_mark": {
+          "name": "Freigetränk",
+          "description": "Als Freigetränk buchen"
+        },
+        "comment": {
+          "name": "Kommentar",
+          "description": "Grund für das Freigetränk"
         }
       }
     },
@@ -283,6 +307,14 @@
         "count": {
           "name": "Anzahl",
           "description": "Anzahl der zu entfernenden Getränke"
+        },
+        "free_mark": {
+          "name": "Freigetränk",
+          "description": "Freigetränk entfernen"
+        },
+        "comment": {
+          "name": "Kommentar",
+          "description": "Grund für das Freigetränk"
         }
       }
     },

--- a/custom_components/tally_list/translations/en.json
+++ b/custom_components/tally_list/translations/en.json
@@ -117,6 +117,7 @@
           "menu_options": {
             "user": "User settings",
             "drinks": "Drink settings",
+            "free_marks": "Free drinks settings",
             "cleanup": "Remove unused sensors",
             "delete": "Delete all entries",
             "finish": "Done"
@@ -141,6 +142,20 @@
             "edit": "Edit price",
             "currency": "Set currency",
             "back": "Back"
+          }
+        },
+        "free_marks": {
+          "title": "Free drinks settings",
+          "data": {
+            "enable_free_marks": "Enable free drinks",
+            "cash_user_name": "Cash user name"
+          }
+        },
+        "disable_free_marks": {
+          "title": "Disable free drinks",
+          "description": "This will remove the cash user and all its tallies. Type \"YES I WANT\" to confirm.",
+          "data": {
+            "confirm": "Confirmation"
           }
         },
         "add_drink": {
@@ -233,6 +248,7 @@
         "action": {
           "user": "User settings",
           "drinks": "Drink settings",
+          "free_marks": "Free drinks settings",
           "add": "Add drink",
           "remove": "Remove drink",
           "edit": "Edit price",
@@ -265,6 +281,14 @@
         "count": {
           "name": "Count",
           "description": "Number of drinks to add"
+        },
+        "free_mark": {
+          "name": "Free mark",
+          "description": "Book as free mark"
+        },
+        "comment": {
+          "name": "Comment",
+          "description": "Reason for free mark"
         }
       }
     },
@@ -283,6 +307,14 @@
         "count": {
           "name": "Count",
           "description": "Number of drinks to remove"
+        },
+        "free_mark": {
+          "name": "Free mark",
+          "description": "Remove free mark"
+        },
+        "comment": {
+          "name": "Comment",
+          "description": "Reason for free mark"
         }
       }
     },


### PR DESCRIPTION
## Summary
- add optional free mark booking and ledger events
- expose configuration to enable free marks with localized cash user name
- document new service parameters for free marks

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689847dee7e0832e9bca3562eeed7f6d