### PR TITLE
Add backend support for free drink marks

### DIFF
--- a/custom_components/tally_list/__init__.py
+++ b/custom_components/tally_list/__init__.py
@@ -6,10 +6,11 @@ import csv
 import os
 from datetime import datetime, timedelta
 
+from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.typing import ConfigType
-from homeassistant.exceptions import Unauthorized
+from homeassistant.exceptions import Unauthorized, HomeAssistantError
 from homeassistant.util.dt import now as dt_now
 
 from .websocket import async_register as async_register_ws
@@ -23,12 +24,21 @@ from .const import (
     SERVICE_EXPORT_CSV,
     ATTR_USER,
     ATTR_DRINK,
+    ATTR_FREE_MARK,
+    ATTR_COMMENT,
     CONF_USER,
     CONF_FREE_AMOUNT,
     CONF_EXCLUDED_USERS,
     CONF_OVERRIDE_USERS,
     PRICE_LIST_USERS,
     CONF_CURRENCY,
+    CONF_ENABLE_FREE_MARKS,
+    CONF_CASH_USER_NAME,
+    FREE_MARK_ERROR_DISABLED,
+    FREE_MARK_ERROR_COMMENT,
+    FREE_MARK_ERROR_CASH_USER,
+    FREE_MARK_ERROR_CANNOT_REMOVE,
+    get_cash_user_name,
 )
 
 PLATFORMS: list[str] = ["sensor", "button"]
@@ -43,6 +53,10 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             CONF_EXCLUDED_USERS: [],
             CONF_OVERRIDE_USERS: [],
             CONF_CURRENCY: "€",
+            CONF_ENABLE_FREE_MARKS: False,
+            CONF_CASH_USER_NAME: get_cash_user_name(
+                getattr(hass.config, "language", None)
+            ),
         },
     )
 
@@ -66,6 +80,50 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         if person_name != target_user:
             raise Unauthorized
 
+    def _log_free_mark(name: str, drink: str, count: int, comment: str) -> None:
+        now = dt_now()
+        path = hass.config.path(
+            "backup",
+            "tally_list",
+            "free_marks",
+            f"free_marks_{now.year}.csv",
+        )
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        timestamp = now.strftime("%Y-%m-%d %H:%M")
+        line = f"{timestamp};{name};{drink} x{count};{comment}\n"
+        if os.path.exists(path):
+            with open(path, "r+", encoding="utf-8") as f:
+                lines = f.readlines()
+                if len(lines) > 1:
+                    last = lines[-1].strip().split(";")
+                    if (
+                        len(last) == 4
+                        and last[0] == timestamp
+                        and last[1] == name
+                        and last[3] == comment
+                    ):
+                        drinks = {}
+                        for part in last[2].split(","):
+                            part = part.strip()
+                            if " x" in part:
+                                dname, qty = part.rsplit(" x", 1)
+                                drinks[dname] = int(qty)
+                        drinks[drink] = drinks.get(drink, 0) + count
+                        new_drinks = ", ".join(
+                            f"{d} x{q}" for d, q in sorted(drinks.items())
+                        )
+                        lines[-1] = f"{timestamp};{name};{new_drinks};{comment}\n"
+                        f.seek(0)
+                        f.writelines(lines)
+                        f.truncate()
+                        return
+                f.seek(0, os.SEEK_END)
+                f.write(line)
+        else:
+            with open(path, "w", encoding="utf-8") as f:
+                f.write("Uhrzeit;Name;Getränke mit Anzahl;Kommentar\n")
+                f.write(line)
+
     async def adjust_count_service(call):
         user = call.data[ATTR_USER]
         await _verify_permissions(call, user)
@@ -86,6 +144,33 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         await _verify_permissions(call, user)
         drink = call.data[ATTR_DRINK]
         count = max(0, call.data.get("count", 1))
+        if call.data.get(ATTR_FREE_MARK):
+            if not hass.data.get(DOMAIN, {}).get(CONF_ENABLE_FREE_MARKS):
+                raise HomeAssistantError(FREE_MARK_ERROR_DISABLED)
+            comment = call.data.get(ATTR_COMMENT, "") or ""
+            if len(comment) < 3 or len(comment) > 200:
+                raise HomeAssistantError(FREE_MARK_ERROR_COMMENT)
+            cash_name = hass.data[DOMAIN].get(
+                CONF_CASH_USER_NAME, get_cash_user_name(hass.config.language)
+            )
+            cash_data = None
+            for entry_id, data in hass.data[DOMAIN].items():
+                if not isinstance(data, dict) or "entry" not in data:
+                    continue
+                if data["entry"].data.get("user") == cash_name:
+                    cash_data = data
+                    break
+            if cash_data is None:
+                raise HomeAssistantError(FREE_MARK_ERROR_CASH_USER)
+            counts = cash_data.setdefault("counts", {})
+            new_count = counts.get(drink, 0) + count
+            counts[drink] = new_count
+            for sensor in cash_data.get("sensors", []):
+                await sensor.async_update_state()
+            await hass.async_add_executor_job(
+                _log_free_mark, user, drink, count, comment
+            )
+            return
         for entry_id, data in hass.data[DOMAIN].items():
             if not isinstance(data, dict) or "entry" not in data:
                 continue
@@ -102,6 +187,35 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         await _verify_permissions(call, user)
         drink = call.data[ATTR_DRINK]
         count = max(0, call.data.get("count", 1))
+        if call.data.get(ATTR_FREE_MARK):
+            if not hass.data.get(DOMAIN, {}).get(CONF_ENABLE_FREE_MARKS):
+                raise HomeAssistantError(FREE_MARK_ERROR_DISABLED)
+            comment = call.data.get(ATTR_COMMENT, "") or ""
+            if len(comment) < 3 or len(comment) > 200:
+                raise HomeAssistantError(FREE_MARK_ERROR_COMMENT)
+            cash_name = hass.data[DOMAIN].get(
+                CONF_CASH_USER_NAME, get_cash_user_name(hass.config.language)
+            )
+            cash_data = None
+            for entry_id, data in hass.data[DOMAIN].items():
+                if not isinstance(data, dict) or "entry" not in data:
+                    continue
+                if data["entry"].data.get("user") == cash_name:
+                    cash_data = data
+                    break
+            if cash_data is None:
+                raise HomeAssistantError(FREE_MARK_ERROR_CASH_USER)
+            counts = cash_data.setdefault("counts", {})
+            current = counts.get(drink, 0)
+            if current < count:
+                raise HomeAssistantError(FREE_MARK_ERROR_CANNOT_REMOVE)
+            counts[drink] = current - count
+            for sensor in cash_data.get("sensors", []):
+                await sensor.async_update_state()
+            await hass.async_add_executor_job(
+                _log_free_mark, user, drink, count, f"Storno: {comment}"
+            )
+            return
         for entry_id, data in hass.data[DOMAIN].items():
             if not isinstance(data, dict) or "entry" not in data:
                 continue
@@ -289,6 +403,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             CONF_EXCLUDED_USERS: [],
             CONF_OVERRIDE_USERS: [],
             CONF_CURRENCY: "€",
+            CONF_ENABLE_FREE_MARKS: False,
+            CONF_CASH_USER_NAME: get_cash_user_name(
+                getattr(hass.config, "language", None)
+            ),
         },
     )
     hass.data[DOMAIN].setdefault(entry.entry_id, {"entry": entry, "counts": {}})
@@ -377,10 +495,82 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             CONF_EXCLUDED_USERS: hass.data[DOMAIN].get("excluded_users", []),
             CONF_OVERRIDE_USERS: hass.data[DOMAIN].get("override_users", []),
             CONF_CURRENCY: hass.data[DOMAIN][CONF_CURRENCY],
+            CONF_ENABLE_FREE_MARKS: hass.data[DOMAIN].get(
+                CONF_ENABLE_FREE_MARKS, False
+            ),
+            CONF_CASH_USER_NAME: hass.data[DOMAIN].get(
+                CONF_CASH_USER_NAME,
+                get_cash_user_name(getattr(hass.config, "language", None)),
+            ),
         }
         if "drinks" in hass.data[DOMAIN]:
             entry_data["drinks"] = hass.data[DOMAIN]["drinks"]
         hass.config_entries.async_update_entry(entry, data=entry_data)
+    if (
+        not hass.data[DOMAIN].get(CONF_ENABLE_FREE_MARKS)
+        and entry.data.get(CONF_ENABLE_FREE_MARKS) is not None
+    ):
+        hass.data[DOMAIN][CONF_ENABLE_FREE_MARKS] = entry.data[
+            CONF_ENABLE_FREE_MARKS
+        ]
+    if (
+        hass.data[DOMAIN].get(CONF_ENABLE_FREE_MARKS) is not None
+        and CONF_ENABLE_FREE_MARKS not in entry.data
+    ):
+        entry_data = {
+            "user": entry.data.get("user"),
+            CONF_FREE_AMOUNT: hass.data[DOMAIN].get("free_amount", 0.0),
+            CONF_EXCLUDED_USERS: hass.data[DOMAIN].get("excluded_users", []),
+            CONF_OVERRIDE_USERS: hass.data[DOMAIN].get("override_users", []),
+            CONF_CURRENCY: hass.data[DOMAIN].get(CONF_CURRENCY, "€"),
+            CONF_ENABLE_FREE_MARKS: hass.data[DOMAIN][CONF_ENABLE_FREE_MARKS],
+            CONF_CASH_USER_NAME: hass.data[DOMAIN].get(
+                CONF_CASH_USER_NAME,
+                get_cash_user_name(getattr(hass.config, "language", None)),
+            ),
+        }
+        if "drinks" in hass.data[DOMAIN]:
+            entry_data["drinks"] = hass.data[DOMAIN]["drinks"]
+        hass.config_entries.async_update_entry(entry, data=entry_data)
+    if (
+        not hass.data[DOMAIN].get(CONF_CASH_USER_NAME)
+        and entry.data.get(CONF_CASH_USER_NAME) is not None
+    ):
+        hass.data[DOMAIN][CONF_CASH_USER_NAME] = entry.data[CONF_CASH_USER_NAME]
+    if (
+        hass.data[DOMAIN].get(CONF_CASH_USER_NAME) is not None
+        and CONF_CASH_USER_NAME not in entry.data
+    ):
+        entry_data = {
+            "user": entry.data.get("user"),
+            CONF_FREE_AMOUNT: hass.data[DOMAIN].get("free_amount", 0.0),
+            CONF_EXCLUDED_USERS: hass.data[DOMAIN].get("excluded_users", []),
+            CONF_OVERRIDE_USERS: hass.data[DOMAIN].get("override_users", []),
+            CONF_CURRENCY: hass.data[DOMAIN].get(CONF_CURRENCY, "€"),
+            CONF_ENABLE_FREE_MARKS: hass.data[DOMAIN].get(
+                CONF_ENABLE_FREE_MARKS, False
+            ),
+            CONF_CASH_USER_NAME: hass.data[DOMAIN][CONF_CASH_USER_NAME],
+        }
+        if "drinks" in hass.data[DOMAIN]:
+            entry_data["drinks"] = hass.data[DOMAIN]["drinks"]
+        hass.config_entries.async_update_entry(entry, data=entry_data)
+    if hass.data[DOMAIN].get(CONF_ENABLE_FREE_MARKS):
+        cash_name = hass.data[DOMAIN].get(
+            CONF_CASH_USER_NAME,
+            get_cash_user_name(getattr(hass.config, "language", None)),
+        )
+        if not any(
+            e.data.get(CONF_USER) == cash_name
+            for e in hass.config_entries.async_entries(DOMAIN)
+        ):
+            hass.async_create_task(
+                hass.config_entries.flow.async_init(
+                    DOMAIN,
+                    context={"source": config_entries.SOURCE_IMPORT, "is_system": True},
+                    data={CONF_USER: cash_name},
+                )
+            )
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 

--- a/custom_components/tally_list/config_flow.py
+++ b/custom_components/tally_list/config_flow.py
@@ -22,6 +22,9 @@ from .const import (
     PRICE_LIST_USERS,
     get_price_list_user,
     CONF_CURRENCY,
+    CONF_ENABLE_FREE_MARKS,
+    CONF_CASH_USER_NAME,
+    get_cash_user_name,
 )
 
 
@@ -167,6 +170,49 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return await self.async_step_menu()
         schema = vol.Schema({vol.Required(CONF_CURRENCY, default=self._currency): str})
         return self.async_show_form(step_id="currency", data_schema=schema)
+
+    async def async_step_free_marks(self, user_input=None):
+        errors = {}
+        if user_input is not None:
+            enable = user_input.get(CONF_ENABLE_FREE_MARKS, False)
+            name = user_input.get(CONF_CASH_USER_NAME, self._cash_user_name)
+            if enable:
+                self._enable_free_marks = True
+                self._cash_user_name = name
+                self.hass.data.setdefault(DOMAIN, {})[CONF_ENABLE_FREE_MARKS] = True
+                self.hass.data[DOMAIN][CONF_CASH_USER_NAME] = name
+                await self._ensure_cash_user()
+                return await self.async_step_menu()
+            if self._enable_free_marks:
+                confirmation = user_input.get("confirm", "").strip().upper()
+                if confirmation in {"JA ICH WILL", "YES I WANT"}:
+                    self._enable_free_marks = False
+                    self.hass.data.setdefault(DOMAIN, {})[CONF_ENABLE_FREE_MARKS] = False
+                    await self._remove_cash_user()
+                    return await self.async_step_menu()
+                errors["base"] = "invalid_confirmation"
+            else:
+                self._enable_free_marks = False
+                self.hass.data.setdefault(DOMAIN, {})[CONF_ENABLE_FREE_MARKS] = False
+                return await self.async_step_menu()
+        if self._enable_free_marks:
+            schema = vol.Schema(
+                {
+                    vol.Required(CONF_ENABLE_FREE_MARKS, default=True): bool,
+                    vol.Required(CONF_CASH_USER_NAME, default=self._cash_user_name): str,
+                    vol.Required("confirm"): str,
+                }
+            )
+        else:
+            schema = vol.Schema(
+                {
+                    vol.Required(CONF_ENABLE_FREE_MARKS, default=False): bool,
+                    vol.Required(CONF_CASH_USER_NAME, default=self._cash_user_name): str,
+                }
+            )
+        return self.async_show_form(
+            step_id="free_marks", data_schema=schema, errors=errors
+        )
 
     async def async_step_exclude(self, user_input=None):
         return await self.async_step_add_excluded_user(user_input)
@@ -370,6 +416,8 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self.hass.data[DOMAIN][CONF_EXCLUDED_USERS] = self._excluded_users
         self.hass.data[DOMAIN][CONF_OVERRIDE_USERS] = self._override_users
         self.hass.data[DOMAIN][CONF_CURRENCY] = self._currency
+        self.hass.data[DOMAIN][CONF_ENABLE_FREE_MARKS] = self._enable_free_marks
+        self.hass.data[DOMAIN][CONF_CASH_USER_NAME] = self._cash_user_name
         if self._create_price_user:
             self.hass.async_create_task(
                 self.hass.config_entries.flow.async_init(
@@ -427,6 +475,8 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
         self._excluded_users: list[str] = []
         self._override_users: list[str] = []
         self._currency: str = "€"
+        self._enable_free_marks: bool = False
+        self._cash_user_name: str = get_cash_user_name(None)
 
     async def async_step_init(self, user_input=None):
         self._drinks = self.hass.data.get(DOMAIN, {}).get("drinks", {}).copy()
@@ -438,6 +488,13 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
             self.hass.data.get(DOMAIN, {}).get(CONF_OVERRIDE_USERS, [])
         ).copy()
         self._currency = self.hass.data.get(DOMAIN, {}).get(CONF_CURRENCY, "€")
+        self._enable_free_marks = self.hass.data.get(DOMAIN, {}).get(
+            CONF_ENABLE_FREE_MARKS, False
+        )
+        self._cash_user_name = self.hass.data.get(DOMAIN, {}).get(
+            CONF_CASH_USER_NAME,
+            get_cash_user_name(getattr(self.hass.config, "language", None)),
+        )
         return await self.async_step_menu()
 
     async def async_step_menu(self, user_input=None):
@@ -446,6 +503,7 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
             menu_options=[
                 "user",
                 "drinks",
+                "free_marks",
                 "cleanup",
                 "delete",
                 "finish",
@@ -510,6 +568,49 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
 
     async def async_step_unauthorize(self, user_input=None):
         return await self.async_step_remove_override_user(user_input)
+
+    async def async_step_free_marks(self, user_input=None):
+        errors = {}
+        if user_input is not None:
+            enable = user_input.get(CONF_ENABLE_FREE_MARKS, False)
+            name = user_input.get(CONF_CASH_USER_NAME, self._cash_user_name)
+            if enable:
+                self._enable_free_marks = True
+                self._cash_user_name = name
+                self.hass.data.setdefault(DOMAIN, {})[CONF_ENABLE_FREE_MARKS] = True
+                self.hass.data[DOMAIN][CONF_CASH_USER_NAME] = name
+                await self._ensure_cash_user()
+                return await self.async_step_menu()
+            if self._enable_free_marks:
+                confirmation = user_input.get("confirm", "").strip().upper()
+                if confirmation in {"JA ICH WILL", "YES I WANT"}:
+                    self._enable_free_marks = False
+                    self.hass.data.setdefault(DOMAIN, {})[CONF_ENABLE_FREE_MARKS] = False
+                    await self._remove_cash_user()
+                    return await self.async_step_menu()
+                errors["base"] = "invalid_confirmation"
+            else:
+                self._enable_free_marks = False
+                self.hass.data.setdefault(DOMAIN, {})[CONF_ENABLE_FREE_MARKS] = False
+                return await self.async_step_menu()
+        if self._enable_free_marks:
+            schema = vol.Schema(
+                {
+                    vol.Required(CONF_ENABLE_FREE_MARKS, default=True): bool,
+                    vol.Required(CONF_CASH_USER_NAME, default=self._cash_user_name): str,
+                    vol.Required("confirm"): str,
+                }
+            )
+        else:
+            schema = vol.Schema(
+                {
+                    vol.Required(CONF_ENABLE_FREE_MARKS, default=False): bool,
+                    vol.Required(CONF_CASH_USER_NAME, default=self._cash_user_name): str,
+                }
+            )
+        return self.async_show_form(
+            step_id="free_marks", data_schema=schema, errors=errors
+        )
 
     async def async_step_cleanup(self, user_input=None):
         errors = {}
@@ -750,6 +851,24 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
             data_schema=schema,
         )
 
+    async def _ensure_cash_user(self) -> None:
+        entries = self.hass.config_entries.async_entries(DOMAIN)
+        if not any(entry.data.get(CONF_USER) == self._cash_user_name for entry in entries):
+            self.hass.async_create_task(
+                self.hass.config_entries.flow.async_init(
+                    DOMAIN,
+                    context={"source": config_entries.SOURCE_IMPORT, "is_system": True},
+                    data={CONF_USER: self._cash_user_name},
+                )
+            )
+
+    async def _remove_cash_user(self) -> None:
+        entries = self.hass.config_entries.async_entries(DOMAIN)
+        for entry in entries:
+            if entry.data.get(CONF_USER) == self._cash_user_name:
+                await self.hass.config_entries.async_remove(entry.entry_id)
+                break
+
     async def _cleanup_unused_entities(self) -> list[str]:
         registry = er.async_get(self.hass)
         entries = self.hass.config_entries.async_entries(DOMAIN)
@@ -847,6 +966,8 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
                 CONF_EXCLUDED_USERS: self._excluded_users,
                 CONF_OVERRIDE_USERS: self._override_users,
                 CONF_CURRENCY: self._currency,
+                CONF_ENABLE_FREE_MARKS: self._enable_free_marks,
+                CONF_CASH_USER_NAME: self._cash_user_name,
             }
             self.hass.config_entries.async_update_entry(entry, data=data)
             await self.hass.config_entries.async_reload(entry.entry_id)
@@ -862,5 +983,7 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
                 CONF_EXCLUDED_USERS: self._excluded_users,
                 CONF_OVERRIDE_USERS: self._override_users,
                 CONF_CURRENCY: self._currency,
+                CONF_ENABLE_FREE_MARKS: self._enable_free_marks,
+                CONF_CASH_USER_NAME: self._cash_user_name,
             },
         )

--- a/custom_components/tally_list/const.py
+++ b/custom_components/tally_list/const.py
@@ -8,9 +8,13 @@ CONF_FREE_AMOUNT = "free_amount"
 CONF_EXCLUDED_USERS = "excluded_users"
 CONF_OVERRIDE_USERS = "override_users"
 CONF_CURRENCY = "currency"
+CONF_ENABLE_FREE_MARKS = "enable_free_marks"
+CONF_CASH_USER_NAME = "cash_user_name"
 
 ATTR_USER = "user"
 ATTR_DRINK = "drink"
+ATTR_FREE_MARK = "free_mark"
+ATTR_COMMENT = "comment"
 
 SERVICE_ADD_DRINK = "add_drink"
 SERVICE_REMOVE_DRINK = "remove_drink"
@@ -25,9 +29,25 @@ PRICE_LIST_USER_EN = "Price list"
 PRICE_LIST_USER = PRICE_LIST_USER_DE
 PRICE_LIST_USERS = {PRICE_LIST_USER_DE, PRICE_LIST_USER_EN}
 
+FREE_MARK_ERROR_DISABLED = "FREE_MARKS_DISABLED"
+FREE_MARK_ERROR_COMMENT = "COMMENT_REQUIRED"
+FREE_MARK_ERROR_CASH_USER = "CASH_USER_MISSING"
+FREE_MARK_ERROR_CANNOT_REMOVE = "CANNOT_REMOVE_COUNT"
+FREE_MARK_ERROR_CONFIRMATION = "CONFIRMATION_REQUIRED"
+
+CASH_USER_NAME_DE = "Freigetränke"
+CASH_USER_NAME_EN = "Free Drinks"
+
 
 def get_price_list_user(language: str | None) -> str:
     """Return localized price list user name."""
     if language and language.lower().startswith("de"):
         return PRICE_LIST_USER_DE
     return PRICE_LIST_USER_EN
+
+
+def get_cash_user_name(language: str | None) -> str:
+    """Return localized cash user name."""
+    if language and language.lower().startswith("de"):
+        return CASH_USER_NAME_DE
+    return CASH_USER_NAME_EN

--- a/custom_components/tally_list/services.yaml
+++ b/custom_components/tally_list/services.yaml
@@ -22,6 +22,16 @@ add_drink:
         number:
           min: 1
           step: 1
+    free_mark:
+      description: Mark drink as free
+      required: false
+      selector:
+        boolean:
+    comment:
+      description: Required comment when free_mark is true
+      required: false
+      selector:
+        text:
 remove_drink:
   name: Remove drink
   description: Decrement drink counter for a person
@@ -46,6 +56,16 @@ remove_drink:
         number:
           min: 1
           step: 1
+    free_mark:
+      description: Remove free mark from cash user
+      required: false
+      selector:
+        boolean:
+    comment:
+      description: Required comment when free_mark is true
+      required: false
+      selector:
+        text:
 adjust_count:
   name: Adjust count
   description: Set drink count for a person

--- a/custom_components/tally_list/translations/de.json
+++ b/custom_components/tally_list/translations/de.json
@@ -117,6 +117,7 @@
           "menu_options": {
             "user": "Nutzereinstellungen",
             "drinks": "Getränkeeinstellungen",
+            "free_marks": "Freibuchungen",
             "cleanup": "Nicht mehr genutzte Sensoren entfernen",
             "delete": "Alle Einträge löschen",
             "finish": "Fertig"
@@ -141,6 +142,14 @@
             "edit": "Bearbeiten",
             "currency": "Währung setzen",
             "back": "Zurück"
+          }
+        },
+        "free_marks": {
+          "title": "Freibuchungen",
+          "data": {
+            "enable_free_marks": "Freibuchungen aktivieren",
+            "cash_user_name": "Name des Kassen-Nutzers",
+            "confirm": "Bestätigung"
           }
         },
         "add_drink": {
@@ -242,6 +251,7 @@
           "include": "Person einschließen",
           "authorize": "Adminrechte vergeben",
           "unauthorize": "Adminrechte entziehen",
+          "free_marks": "Freibuchungen",
           "cleanup": "Nicht mehr genutzte Sensoren entfernen",
           "delete": "Alle Einträge löschen",
           "finish": "Fertig",
@@ -265,6 +275,14 @@
         "count": {
           "name": "Anzahl",
           "description": "Anzahl der hinzuzufügenden Getränke"
+        },
+        "free_mark": {
+          "name": "Freibuchung",
+          "description": "Getränk als frei buchen"
+        },
+        "comment": {
+          "name": "Kommentar",
+          "description": "Erforderlicher Kommentar bei Freibuchung"
         }
       }
     },
@@ -283,6 +301,14 @@
         "count": {
           "name": "Anzahl",
           "description": "Anzahl der zu entfernenden Getränke"
+        },
+        "free_mark": {
+          "name": "Freibuchung",
+          "description": "Freibuchung beim Kassen-Nutzer entfernen"
+        },
+        "comment": {
+          "name": "Kommentar",
+          "description": "Erforderlicher Kommentar bei Freibuchung"
         }
       }
     },

--- a/custom_components/tally_list/translations/en.json
+++ b/custom_components/tally_list/translations/en.json
@@ -117,6 +117,7 @@
           "menu_options": {
             "user": "User settings",
             "drinks": "Drink settings",
+            "free_marks": "Free drink settings",
             "cleanup": "Remove unused sensors",
             "delete": "Delete all entries",
             "finish": "Done"
@@ -141,6 +142,14 @@
             "edit": "Edit price",
             "currency": "Set currency",
             "back": "Back"
+          }
+        },
+        "free_marks": {
+          "title": "Free drink settings",
+          "data": {
+            "enable_free_marks": "Enable free marks",
+            "cash_user_name": "Cash user name",
+            "confirm": "Confirmation"
           }
         },
         "add_drink": {
@@ -242,6 +251,7 @@
           "include": "Include person",
           "authorize": "Grant admin rights",
           "unauthorize": "Revoke admin rights",
+          "free_marks": "Free drink settings",
           "cleanup": "Remove unused sensors",
           "delete": "Delete all entries",
           "finish": "Done",
@@ -265,6 +275,14 @@
         "count": {
           "name": "Count",
           "description": "Number of drinks to add"
+        },
+        "free_mark": {
+          "name": "Free mark",
+          "description": "Book drink as free"
+        },
+        "comment": {
+          "name": "Comment",
+          "description": "Required comment when free mark is used"
         }
       }
     },
@@ -283,6 +301,14 @@
         "count": {
           "name": "Count",
           "description": "Number of drinks to remove"
+        },
+        "free_mark": {
+          "name": "Free mark",
+          "description": "Remove free mark from cash user"
+        },
+        "comment": {
+          "name": "Comment",
+          "description": "Required comment when free mark is used"
         }
       }
     },


### PR DESCRIPTION
## Summary
- add configuration and constants for free drink marks and cash user
- extend services to handle free marks with comment logging
- log free mark actions to CSV and manage cash user through options flow
- fix options flow to stop recreating the cash user after disabling free marks

## Testing
- `python -m py_compile custom_components/tally_list/config_flow.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68984748b008832eb24d6a78a0f05f02