### PR TITLE
feat: add free mark support

### DIFF
--- a/custom_components/tally_list/__init__.py
+++ b/custom_components/tally_list/__init__.py
@@ -4,13 +4,15 @@ from __future__ import annotations
 
 import csv
 import os
+import re
 from datetime import datetime, timedelta
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.typing import ConfigType
-from homeassistant.exceptions import Unauthorized
+from homeassistant.exceptions import HomeAssistantError, Unauthorized
 from homeassistant.util.dt import now as dt_now
+from homeassistant.util import dt as dt_util
 
 from .websocket import async_register as async_register_ws
 
@@ -29,6 +31,11 @@ from .const import (
     CONF_OVERRIDE_USERS,
     PRICE_LIST_USERS,
     CONF_CURRENCY,
+    CONF_ENABLE_FREE_MARKS,
+    CONF_CASH_USER_NAME,
+    ATTR_FREE_MARK,
+    ATTR_COMMENT,
+    get_cash_user_name,
 )
 
 PLATFORMS: list[str] = ["sensor", "button"]
@@ -43,6 +50,10 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             CONF_EXCLUDED_USERS: [],
             CONF_OVERRIDE_USERS: [],
             CONF_CURRENCY: "€",
+            CONF_ENABLE_FREE_MARKS: False,
+            CONF_CASH_USER_NAME: get_cash_user_name(hass.config.language),
+            "free_mark_counts": {},
+            "free_marks_ledger": 0.0,
         },
     )
 
@@ -66,6 +77,47 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         if person_name != target_user:
             raise Unauthorized
 
+    def _write_free_mark_log(name: str, drink: str, count: int, comment: str) -> None:
+        tz = dt_util.get_time_zone("Europe/Berlin")
+        ts = dt_util.now(tz).replace(second=0, microsecond=0)
+        base_dir = hass.config.path("backup", "tally_list", "free_marks")
+        os.makedirs(base_dir, exist_ok=True)
+        path = os.path.join(base_dir, f"free_marks_{ts.year}.csv")
+        key_time = ts.strftime("%Y-%m-%dT%H:%M")
+        comment_clean = re.sub(r"[\n\r\t]", " ", comment).strip()[:200]
+        rows: list[list[str]] = []
+        if os.path.exists(path):
+            with open(path, "r", encoding="utf-8", newline="") as csvfile:
+                rows = list(csv.reader(csvfile, delimiter=";"))
+        if not rows:
+            rows = [["Uhrzeit", "Name", "Getränke mit Anzahl", "Kommentar"]]
+        last_key = None
+        if len(rows) > 1:
+            last = rows[-1]
+            last_key = (last[0], last[1], last[3])
+        key = (key_time, name, comment_clean)
+        if key == last_key:
+            drink_map: dict[str, int] = {}
+            if rows[-1][2]:
+                for part in rows[-1][2].split(","):
+                    part = part.strip()
+                    if not part:
+                        continue
+                    dname, dcount = part.rsplit(" x", 1)
+                    drink_map[dname] = int(dcount)
+            drink_map[drink] = drink_map.get(drink, 0) + count
+            drink_map = {k: v for k, v in drink_map.items() if v != 0}
+            drink_str = ", ".join(
+                f"{k} x{v}" for k, v in sorted(drink_map.items())
+            )
+            rows[-1][2] = drink_str
+        else:
+            drink_str = f"{drink} x{count}"
+            rows.append([key_time, name, drink_str, comment_clean])
+        with open(path, "w", encoding="utf-8", newline="") as csvfile:
+            writer = csv.writer(csvfile, delimiter=";", quoting=csv.QUOTE_MINIMAL)
+            writer.writerows(rows)
+
     async def adjust_count_service(call):
         user = call.data[ATTR_USER]
         await _verify_permissions(call, user)
@@ -86,6 +138,59 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         await _verify_permissions(call, user)
         drink = call.data[ATTR_DRINK]
         count = max(0, call.data.get("count", 1))
+        free_mark = call.data.get(ATTR_FREE_MARK, False)
+        comment = call.data.get(ATTR_COMMENT, "")
+        if free_mark:
+            if not hass.data[DOMAIN].get(CONF_ENABLE_FREE_MARKS):
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN,
+                    translation_key="free_marks_disabled",
+                )
+            cash_name = hass.data[DOMAIN].get(CONF_CASH_USER_NAME)
+            if not cash_name:
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN, translation_key="cash_user_missing"
+                )
+            comment = comment.strip()
+            if len(comment) < 3 or len(comment) > 200:
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN, translation_key="comment_required"
+                )
+            if drink not in hass.data[DOMAIN].get("drinks", {}):
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN, translation_key="drink_unknown"
+                )
+            cash_entry = None
+            for data in hass.data[DOMAIN].values():
+                if (
+                    isinstance(data, dict)
+                    and "entry" in data
+                    and data["entry"].data.get(CONF_USER, "").strip().lower()
+                    == cash_name.strip().lower()
+                ):
+                    cash_entry = data
+                    break
+            if cash_entry is None:
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN, translation_key="cash_user_missing"
+                )
+            counts = cash_entry.setdefault("counts", {})
+            counts[drink] = counts.get(drink, 0) + count
+            hass.data[DOMAIN]["free_mark_counts"] = counts
+            for sensor in cash_entry.get("sensors", []):
+                await sensor.async_update_state()
+            price = hass.data[DOMAIN]["drinks"].get(drink, 0.0)
+            hass.data[DOMAIN]["free_marks_ledger"] = hass.data[DOMAIN].get(
+                "free_marks_ledger", 0.0
+            ) + price * count
+            await hass.async_add_executor_job(
+                _write_free_mark_log, user, drink, count, comment
+            )
+            hass.bus.async_fire(
+                "tally_list_free_mark_created",
+                {"user": user, "drink": drink, "count": count, "comment": comment},
+            )
+            return
         for entry_id, data in hass.data[DOMAIN].items():
             if not isinstance(data, dict) or "entry" not in data:
                 continue
@@ -102,6 +207,54 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         await _verify_permissions(call, user)
         drink = call.data[ATTR_DRINK]
         count = max(0, call.data.get("count", 1))
+        free_mark = call.data.get(ATTR_FREE_MARK, False)
+        comment = call.data.get(ATTR_COMMENT, "")
+        if free_mark:
+            if not hass.data[DOMAIN].get(CONF_ENABLE_FREE_MARKS):
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN,
+                    translation_key="free_marks_disabled",
+                )
+            cash_name = hass.data[DOMAIN].get(CONF_CASH_USER_NAME)
+            if not cash_name:
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN, translation_key="cash_user_missing"
+                )
+            cash_entry = None
+            for data in hass.data[DOMAIN].values():
+                if (
+                    isinstance(data, dict)
+                    and "entry" in data
+                    and data["entry"].data.get(CONF_USER, "").strip().lower()
+                    == cash_name.strip().lower()
+                ):
+                    cash_entry = data
+                    break
+            if cash_entry is None:
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN, translation_key="cash_user_missing"
+                )
+            counts = cash_entry.setdefault("counts", {})
+            if counts.get(drink, 0) < count:
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN, translation_key="cannot_remove_count"
+                )
+            counts[drink] -= count
+            for sensor in cash_entry.get("sensors", []):
+                await sensor.async_update_state()
+            price = hass.data[DOMAIN]["drinks"].get(drink, 0.0)
+            hass.data[DOMAIN]["free_marks_ledger"] = hass.data[DOMAIN].get(
+                "free_marks_ledger", 0.0
+            ) - price * count
+            comment = comment.strip()
+            await hass.async_add_executor_job(
+                _write_free_mark_log, user, drink, -count, comment
+            )
+            hass.bus.async_fire(
+                "tally_list_free_mark_reversed",
+                {"user": user, "drink": drink, "count": count, "comment": comment},
+            )
+            return
         for entry_id, data in hass.data[DOMAIN].items():
             if not isinstance(data, dict) or "entry" not in data:
                 continue
@@ -292,6 +445,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         },
     )
     hass.data[DOMAIN].setdefault(entry.entry_id, {"entry": entry, "counts": {}})
+    cash_name = get_cash_user_name(hass.config.language)
+    hass.data[DOMAIN][CONF_CASH_USER_NAME] = cash_name
+    if entry.data.get(CONF_CASH_USER_NAME) != cash_name:
+        entry_data = dict(entry.data)
+        entry_data[CONF_CASH_USER_NAME] = cash_name
+        hass.config_entries.async_update_entry(entry, data=entry_data)
+    if (
+        cash_name
+        and entry.data.get(CONF_USER, "").strip().lower() == cash_name.strip().lower()
+    ):
+        hass.data[DOMAIN]["free_mark_counts"] = hass.data[DOMAIN][entry.entry_id][
+            "counts"
+        ]
     if not hass.data[DOMAIN].get("drinks") and entry.data.get("drinks"):
         hass.data[DOMAIN]["drinks"] = entry.data["drinks"]
     if hass.data[DOMAIN].get("drinks") and not entry.data.get("drinks"):
@@ -377,6 +543,39 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             CONF_EXCLUDED_USERS: hass.data[DOMAIN].get("excluded_users", []),
             CONF_OVERRIDE_USERS: hass.data[DOMAIN].get("override_users", []),
             CONF_CURRENCY: hass.data[DOMAIN][CONF_CURRENCY],
+            CONF_ENABLE_FREE_MARKS: hass.data[DOMAIN].get(CONF_ENABLE_FREE_MARKS, False),
+            CONF_CASH_USER_NAME: hass.data[DOMAIN].get(
+                CONF_CASH_USER_NAME, get_cash_user_name(hass.config.language)
+            ),
+        }
+        if "drinks" in hass.data[DOMAIN]:
+            entry_data["drinks"] = hass.data[DOMAIN]["drinks"]
+        hass.config_entries.async_update_entry(entry, data=entry_data)
+    if (
+        not hass.data[DOMAIN].get(CONF_ENABLE_FREE_MARKS)
+        and entry.data.get(CONF_ENABLE_FREE_MARKS) is not None
+    ):
+        hass.data[DOMAIN][CONF_ENABLE_FREE_MARKS] = entry.data[CONF_ENABLE_FREE_MARKS]
+    if (
+        (hass.data[DOMAIN].get(CONF_ENABLE_FREE_MARKS) is not None
+         and CONF_ENABLE_FREE_MARKS not in entry.data)
+        or (
+            hass.data[DOMAIN].get(CONF_CASH_USER_NAME) is not None
+            and CONF_CASH_USER_NAME not in entry.data
+        )
+    ):
+        entry_data = {
+            "user": entry.data.get("user"),
+            CONF_FREE_AMOUNT: hass.data[DOMAIN].get("free_amount", 0.0),
+            CONF_EXCLUDED_USERS: hass.data[DOMAIN].get("excluded_users", []),
+            CONF_OVERRIDE_USERS: hass.data[DOMAIN].get("override_users", []),
+            CONF_CURRENCY: hass.data[DOMAIN].get(CONF_CURRENCY, "€"),
+            CONF_ENABLE_FREE_MARKS: hass.data[DOMAIN].get(
+                CONF_ENABLE_FREE_MARKS, False
+            ),
+            CONF_CASH_USER_NAME: hass.data[DOMAIN].get(
+                CONF_CASH_USER_NAME, get_cash_user_name(hass.config.language)
+            ),
         }
         if "drinks" in hass.data[DOMAIN]:
             entry_data["drinks"] = hass.data[DOMAIN]["drinks"]
@@ -399,6 +598,15 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             # user is re-added later
             hass.data[DOMAIN].pop(CONF_OVERRIDE_USERS, None)
             hass.data[DOMAIN].pop(CONF_CURRENCY, None)
+            hass.data[DOMAIN].pop(CONF_ENABLE_FREE_MARKS, None)
+            hass.data[DOMAIN].pop(CONF_CASH_USER_NAME, None)
+            hass.data[DOMAIN].pop("free_marks_ledger", None)
+        elif (
+            hass.data[DOMAIN].get(CONF_CASH_USER_NAME)
+            and entry.data.get(CONF_USER, "").strip().lower()
+            == hass.data[DOMAIN][CONF_CASH_USER_NAME].strip().lower()
+        ):
+            hass.data[DOMAIN].pop("free_mark_counts", None)
         if not any(
             isinstance(value, dict) and "entry" in value
             for value in hass.data.get(DOMAIN, {}).values()

--- a/custom_components/tally_list/button.py
+++ b/custom_components/tally_list/button.py
@@ -14,6 +14,8 @@ from .const import (
     CONF_USER,
     CONF_OVERRIDE_USERS,
     PRICE_LIST_USERS,
+    CONF_CASH_USER_NAME,
+    CASH_USER_SLUG,
 )
 
 
@@ -31,7 +33,11 @@ class ResetButton(ButtonEntity):
         user = entry.data[CONF_USER]
         self._attr_name = f"{user} Reset"
         self._attr_unique_id = f"{entry.entry_id}_reset_tally"
-        self.entity_id = f"button.{slugify(user)}_reset_tally"
+        user_slug = slugify(user)
+        cash_name = hass.data.get(DOMAIN, {}).get(CONF_CASH_USER_NAME, "")
+        if user.strip().lower() == cash_name.strip().lower():
+            user_slug = CASH_USER_SLUG
+        self.entity_id = f"button.{user_slug}_reset_tally"
 
     async def async_press(self) -> None:
         user_id = self._context.user_id if self._context else None

--- a/custom_components/tally_list/config_flow.py
+++ b/custom_components/tally_list/config_flow.py
@@ -22,6 +22,9 @@ from .const import (
     PRICE_LIST_USERS,
     get_price_list_user,
     CONF_CURRENCY,
+    CONF_ENABLE_FREE_MARKS,
+    CONF_CASH_USER_NAME,
+    get_cash_user_name,
 )
 
 
@@ -58,6 +61,8 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._currency: str = "€"
         self._create_price_user: bool = False
         self._user_selected: bool = False
+        self._enable_free_marks: bool = False
+        self._cash_user_name: str = get_cash_user_name(None)
 
     async def async_step_import(self, user_input=None):
         """Handle import of a config entry."""
@@ -69,12 +74,22 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._excluded_users = user_input.get(CONF_EXCLUDED_USERS, [])
         self._override_users = user_input.get(CONF_OVERRIDE_USERS, [])
         self._currency = user_input.get(CONF_CURRENCY, "€")
+        self._enable_free_marks = user_input.get(CONF_ENABLE_FREE_MARKS, False)
+        self._cash_user_name = get_cash_user_name(
+            getattr(self.hass.config, "language", None)
+        )
         if CONF_CURRENCY not in user_input:
             user_input[CONF_CURRENCY] = self._currency
+        if CONF_ENABLE_FREE_MARKS not in user_input:
+            user_input[CONF_ENABLE_FREE_MARKS] = self._enable_free_marks
+        user_input[CONF_CASH_USER_NAME] = self._cash_user_name
         return self.async_create_entry(title=self._user, data=user_input)
 
     async def async_step_user(self, user_input=None):
         if not self._user_selected:
+            self._cash_user_name = get_cash_user_name(
+                getattr(self.hass.config, "language", None)
+            )
             registry = er.async_get(self.hass)
             persons = [
                 entry.original_name or entry.name or entry.entity_id
@@ -118,6 +133,12 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     self._override_users = entry.data.get(CONF_OVERRIDE_USERS, [])
                     self._free_amount = float(entry.data.get(CONF_FREE_AMOUNT, 0.0))
                     self._currency = entry.data.get(CONF_CURRENCY, "€")
+                    self._enable_free_marks = entry.data.get(
+                        CONF_ENABLE_FREE_MARKS, False
+                    )
+                    self._cash_user_name = get_cash_user_name(
+                        getattr(self.hass.config, "language", None)
+                    )
                     break
             self._user_selected = True
             return await self.async_step_menu()
@@ -167,6 +188,37 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return await self.async_step_menu()
         schema = vol.Schema({vol.Required(CONF_CURRENCY, default=self._currency): str})
         return self.async_show_form(step_id="currency", data_schema=schema)
+
+    async def async_step_free_marks(self, user_input=None):
+        if user_input is not None:
+            enable = user_input[CONF_ENABLE_FREE_MARKS]
+            if self._enable_free_marks and not enable:
+                return await self.async_step_free_marks_confirm()
+            self._enable_free_marks = enable
+            return await self.async_step_menu()
+        schema = vol.Schema(
+            {
+                vol.Required(
+                    CONF_ENABLE_FREE_MARKS, default=self._enable_free_marks
+                ): bool
+            }
+        )
+        return self.async_show_form(
+            step_id="free_marks", data_schema=schema
+        )
+
+    async def async_step_free_marks_confirm(self, user_input=None):
+        errors = {}
+        if user_input is not None:
+            confirmation = user_input.get("confirm", "").strip().upper()
+            if confirmation in {"JA ICH WILL", "YES I WANT"}:
+                self._enable_free_marks = False
+                return await self.async_step_menu()
+            errors["base"] = "confirmation_required"
+        schema = vol.Schema({vol.Required("confirm"): str})
+        return self.async_show_form(
+            step_id="free_marks_confirm", data_schema=schema, errors=errors
+        )
 
     async def async_step_exclude(self, user_input=None):
         return await self.async_step_add_excluded_user(user_input)
@@ -361,6 +413,8 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 CONF_EXCLUDED_USERS: self._excluded_users,
                 CONF_OVERRIDE_USERS: self._override_users,
                 CONF_CURRENCY: self._currency,
+                CONF_ENABLE_FREE_MARKS: self._enable_free_marks,
+                CONF_CASH_USER_NAME: self._cash_user_name,
             },
         )
 
@@ -370,6 +424,8 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self.hass.data[DOMAIN][CONF_EXCLUDED_USERS] = self._excluded_users
         self.hass.data[DOMAIN][CONF_OVERRIDE_USERS] = self._override_users
         self.hass.data[DOMAIN][CONF_CURRENCY] = self._currency
+        self.hass.data[DOMAIN][CONF_ENABLE_FREE_MARKS] = self._enable_free_marks
+        self.hass.data[DOMAIN][CONF_CASH_USER_NAME] = self._cash_user_name
         if self._create_price_user:
             self.hass.async_create_task(
                 self.hass.config_entries.flow.async_init(
@@ -410,6 +466,32 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 )
             )
         self._pending_users = []
+        if self._enable_free_marks:
+            cash_name = self._cash_user_name.strip()
+            entries = self.hass.config_entries.async_entries(DOMAIN)
+            cash_entry = next(
+                (
+                    entry
+                    for entry in entries
+                    if entry.data.get(CONF_USER, "").strip().lower()
+                    == cash_name.lower()
+                ),
+                None,
+            )
+            if cash_entry is None:
+                self.hass.async_create_task(
+                    self.hass.config_entries.flow.async_init(
+                        DOMAIN,
+                        context={"source": config_entries.SOURCE_IMPORT},
+                        data={CONF_USER: cash_name},
+                    )
+                )
+            else:
+                cash_data = self.hass.data.get(DOMAIN, {}).get(cash_entry.entry_id)
+                if cash_data is not None:
+                    self.hass.data[DOMAIN]["free_mark_counts"] = cash_data.setdefault(
+                        "counts", {}
+                    )
 
     @staticmethod
     @callback
@@ -427,6 +509,8 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
         self._excluded_users: list[str] = []
         self._override_users: list[str] = []
         self._currency: str = "€"
+        self._enable_free_marks: bool = False
+        self._cash_user_name: str = get_cash_user_name(None)
 
     async def async_step_init(self, user_input=None):
         self._drinks = self.hass.data.get(DOMAIN, {}).get("drinks", {}).copy()
@@ -438,6 +522,10 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
             self.hass.data.get(DOMAIN, {}).get(CONF_OVERRIDE_USERS, [])
         ).copy()
         self._currency = self.hass.data.get(DOMAIN, {}).get(CONF_CURRENCY, "€")
+        self._enable_free_marks = self.hass.data.get(DOMAIN, {}).get(
+            CONF_ENABLE_FREE_MARKS, False
+        )
+        self._cash_user_name = get_cash_user_name(self.hass.config.language)
         return await self.async_step_menu()
 
     async def async_step_menu(self, user_input=None):
@@ -446,6 +534,7 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
             menu_options=[
                 "user",
                 "drinks",
+                "free_marks",
                 "cleanup",
                 "delete",
                 "finish",
@@ -498,6 +587,45 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
             return await self.async_step_menu()
         schema = vol.Schema({vol.Required(CONF_CURRENCY, default=self._currency): str})
         return self.async_show_form(step_id="currency", data_schema=schema)
+
+    async def async_step_free_marks(self, user_input=None):
+        if user_input is not None:
+            enable = user_input[CONF_ENABLE_FREE_MARKS]
+            if self._enable_free_marks and not enable:
+                return await self.async_step_free_marks_confirm()
+            self._enable_free_marks = enable
+            return await self.async_step_menu()
+        schema = vol.Schema(
+            {
+                vol.Required(
+                    CONF_ENABLE_FREE_MARKS, default=self._enable_free_marks
+                ): bool
+            }
+        )
+        return self.async_show_form(step_id="free_marks", data_schema=schema)
+
+    async def async_step_free_marks_confirm(self, user_input=None):
+        errors = {}
+        if user_input is not None:
+            confirmation = user_input.get("confirm", "").strip().upper()
+            if confirmation in {"JA ICH WILL", "YES I WANT"}:
+                self._enable_free_marks = False
+                return self.async_show_menu(
+                    step_id="menu",
+                    menu_options=[
+                        "user",
+                        "drinks",
+                        "free_marks",
+                        "cleanup",
+                        "delete",
+                        "finish",
+                    ],
+                )
+            errors["base"] = "confirmation_required"
+        schema = vol.Schema({vol.Required("confirm"): str})
+        return self.async_show_form(
+            step_id="free_marks_confirm", data_schema=schema, errors=errors
+        )
 
     async def async_step_exclude(self, user_input=None):
         return await self.async_step_add_excluded_user(user_input)
@@ -838,6 +966,40 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
         self.hass.data[DOMAIN][CONF_EXCLUDED_USERS] = self._excluded_users
         self.hass.data[DOMAIN][CONF_OVERRIDE_USERS] = self._override_users
         self.hass.data[DOMAIN][CONF_CURRENCY] = self._currency
+        self.hass.data[DOMAIN][CONF_CASH_USER_NAME] = self._cash_user_name
+        cash_name = self._cash_user_name.strip()
+        entries = self.hass.config_entries.async_entries(DOMAIN)
+        cash_entry = next(
+            (
+                e
+                for e in entries
+                if e.data.get(CONF_USER, "").strip().lower() == cash_name.lower()
+            ),
+            None,
+        )
+        if self._enable_free_marks:
+            if cash_entry is None:
+                self.hass.async_create_task(
+                    self.hass.config_entries.flow.async_init(
+                        DOMAIN,
+                        context={"source": config_entries.SOURCE_IMPORT},
+                        data={CONF_USER: cash_name},
+                    )
+                )
+            else:
+                cash_data = self.hass.data.get(DOMAIN, {}).get(cash_entry.entry_id)
+                if cash_data is not None:
+                    self.hass.data[DOMAIN]["free_mark_counts"] = cash_data.setdefault(
+                        "counts", {}
+                    )
+        elif cash_entry is not None:
+            cash_data = self.hass.data.get(DOMAIN, {}).get(cash_entry.entry_id)
+            if cash_data is not None:
+                cash_data["counts"] = {}
+                for sensor in cash_data.get("sensors", []):
+                    await sensor.async_update_state()
+            await self.hass.config_entries.async_remove(cash_entry.entry_id)
+            self.hass.data[DOMAIN].pop("free_mark_counts", None)
 
         for entry in self.hass.config_entries.async_entries(DOMAIN):
             data = {
@@ -847,6 +1009,8 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
                 CONF_EXCLUDED_USERS: self._excluded_users,
                 CONF_OVERRIDE_USERS: self._override_users,
                 CONF_CURRENCY: self._currency,
+                CONF_ENABLE_FREE_MARKS: self._enable_free_marks,
+                CONF_CASH_USER_NAME: self._cash_user_name,
             }
             self.hass.config_entries.async_update_entry(entry, data=data)
             await self.hass.config_entries.async_reload(entry.entry_id)
@@ -862,5 +1026,7 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
                 CONF_EXCLUDED_USERS: self._excluded_users,
                 CONF_OVERRIDE_USERS: self._override_users,
                 CONF_CURRENCY: self._currency,
+                CONF_ENABLE_FREE_MARKS: self._enable_free_marks,
+                CONF_CASH_USER_NAME: self._cash_user_name,
             },
         )

--- a/custom_components/tally_list/const.py
+++ b/custom_components/tally_list/const.py
@@ -9,8 +9,13 @@ CONF_EXCLUDED_USERS = "excluded_users"
 CONF_OVERRIDE_USERS = "override_users"
 CONF_CURRENCY = "currency"
 
+CONF_ENABLE_FREE_MARKS = "enable_free_marks"
+CONF_CASH_USER_NAME = "cash_user_name"
+
 ATTR_USER = "user"
 ATTR_DRINK = "drink"
+ATTR_FREE_MARK = "free_mark"
+ATTR_COMMENT = "comment"
 
 SERVICE_ADD_DRINK = "add_drink"
 SERVICE_REMOVE_DRINK = "remove_drink"
@@ -24,6 +29,17 @@ PRICE_LIST_USER_EN = "Price list"
 # Default name for backward compatibility
 PRICE_LIST_USER = PRICE_LIST_USER_DE
 PRICE_LIST_USERS = {PRICE_LIST_USER_DE, PRICE_LIST_USER_EN}
+
+CASH_USER_DE = "Freigetränke"
+CASH_USER_EN = "Free Drinks"
+CASH_USER_SLUG = "free_drinks"
+
+
+def get_cash_user_name(language: str | None) -> str:
+    """Return localized cash user name."""
+    if language and language.lower().startswith("de"):
+        return CASH_USER_DE
+    return CASH_USER_EN
 
 
 def get_price_list_user(language: str | None) -> str:

--- a/custom_components/tally_list/sensor.py
+++ b/custom_components/tally_list/sensor.py
@@ -8,7 +8,14 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.util import slugify
 
-from .const import DOMAIN, CONF_USER, PRICE_LIST_USERS, CONF_CURRENCY
+from .const import (
+    DOMAIN,
+    CONF_USER,
+    PRICE_LIST_USERS,
+    CONF_CURRENCY,
+    CONF_CASH_USER_NAME,
+    CASH_USER_SLUG,
+)
 
 
 def _local_suffix(hass: HomeAssistant, en: str, de: str) -> str:
@@ -56,9 +63,11 @@ class TallyListSensor(RestoreEntity, SensorEntity):
             f"{_local_suffix(hass, 'Count', 'Anzahl')}"
         )
         self._attr_unique_id = f"{entry.entry_id}_{drink}_count"
-        self.entity_id = (
-            f"sensor.{slugify(entry.data[CONF_USER])}_{slugify(drink)}_count"
-        )
+        user_slug = slugify(entry.data[CONF_USER])
+        cash_name = hass.data.get(DOMAIN, {}).get(CONF_CASH_USER_NAME, "")
+        if entry.data[CONF_USER].strip().lower() == cash_name.strip().lower():
+            user_slug = CASH_USER_SLUG
+        self.entity_id = f"sensor.{user_slug}_{slugify(drink)}_count"
         self._attr_native_value = 0
         self._attr_native_unit_of_measurement = None
 
@@ -172,7 +181,11 @@ class TotalAmountSensor(RestoreEntity, SensorEntity):
             f"{_local_suffix(hass, 'Amount due', 'Offener Betrag')}"
         )
         self._attr_unique_id = f"{entry.entry_id}_amount_due"
-        self.entity_id = f"sensor.{slugify(entry.data[CONF_USER])}_amount_due"
+        user_slug = slugify(entry.data[CONF_USER])
+        cash_name = hass.data.get(DOMAIN, {}).get(CONF_CASH_USER_NAME, "")
+        if entry.data[CONF_USER].strip().lower() == cash_name.strip().lower():
+            user_slug = CASH_USER_SLUG
+        self.entity_id = f"sensor.{user_slug}_amount_due"
         self._attr_native_unit_of_measurement = hass.data.get(DOMAIN, {}).get(
             CONF_CURRENCY, "€"
         )

--- a/custom_components/tally_list/services.yaml
+++ b/custom_components/tally_list/services.yaml
@@ -22,6 +22,16 @@ add_drink:
         number:
           min: 1
           step: 1
+    free_mark:
+      description: Book as free mark
+      required: false
+      selector:
+        boolean:
+    comment:
+      description: Comment for free mark
+      required: false
+      selector:
+        text:
 remove_drink:
   name: Remove drink
   description: Decrement drink counter for a person
@@ -46,6 +56,16 @@ remove_drink:
         number:
           min: 1
           step: 1
+    free_mark:
+      description: Book as free mark
+      required: false
+      selector:
+        boolean:
+    comment:
+      description: Comment for free mark
+      required: false
+      selector:
+        text:
 adjust_count:
   name: Adjust count
   description: Set drink count for a person

--- a/custom_components/tally_list/translations/de.json
+++ b/custom_components/tally_list/translations/de.json
@@ -109,7 +109,8 @@
         "delete_all": "Alle Sensoren und Konfigurationen wurden entfernt."
       },
       "error": {
-        "invalid_confirmation": "Bitte gib \"JA ICH WILL\" ein."
+        "invalid_confirmation": "Bitte gib \"JA ICH WILL\" ein.",
+        "confirmation_required": "Bestätigung erforderlich"
       },
       "step": {
         "menu": {
@@ -117,6 +118,7 @@
           "menu_options": {
             "user": "Nutzereinstellungen",
             "drinks": "Getränkeeinstellungen",
+            "free_marks": "Freimarken",
             "cleanup": "Nicht mehr genutzte Sensoren entfernen",
             "delete": "Alle Einträge löschen",
             "finish": "Fertig"
@@ -141,6 +143,20 @@
             "edit": "Bearbeiten",
             "currency": "Währung setzen",
             "back": "Zurück"
+          }
+        },
+        "free_marks": {
+          "title": "Freimarken",
+          "description": "Freimarken werden auf den Freigetränke-Nutzer gebucht, nicht auf normale Nutzer.",
+          "data": {
+            "enable_free_marks": "Freimarken aktivieren"
+          }
+        },
+        "free_marks_confirm": {
+          "title": "Freimarken deaktivieren",
+          "description": "Gib zur Bestätigung \"JA ICH WILL\" ein",
+          "data": {
+            "confirm": "Bestätigung"
           }
         },
         "add_drink": {
@@ -233,6 +249,7 @@
         "action": {
           "user": "Nutzereinstellungen",
           "drinks": "Getränkeeinstellungen",
+          "free_marks": "Freimarken",
           "add": "Hinzufügen",
           "remove": "Entfernen",
           "edit": "Bearbeiten",
@@ -249,6 +266,13 @@
         }
       }
     },
+  "exceptions": {
+    "free_marks_disabled": "Freimarken sind deaktiviert",
+    "comment_required": "Kommentar erforderlich",
+    "cash_user_missing": "Freigetränke-Nutzer fehlt",
+    "drink_unknown": "Unbekanntes Getränk",
+    "cannot_remove_count": "Anzahl kann nicht entfernt werden"
+  },
   "services": {
     "add_drink": {
       "name": "Getränk hinzufügen",
@@ -265,6 +289,14 @@
         "count": {
           "name": "Anzahl",
           "description": "Anzahl der hinzuzufügenden Getränke"
+        },
+        "free_mark": {
+          "name": "Freimarke",
+          "description": "Als Freimarke buchen"
+        },
+        "comment": {
+          "name": "Kommentar",
+          "description": "Kommentar für Freimarke"
         }
       }
     },
@@ -283,6 +315,14 @@
         "count": {
           "name": "Anzahl",
           "description": "Anzahl der zu entfernenden Getränke"
+        },
+        "free_mark": {
+          "name": "Freimarke",
+          "description": "Als Freimarke buchen"
+        },
+        "comment": {
+          "name": "Kommentar",
+          "description": "Kommentar für Freimarke"
         }
       }
     },

--- a/custom_components/tally_list/translations/en.json
+++ b/custom_components/tally_list/translations/en.json
@@ -109,7 +109,8 @@
       "delete_all": "All sensors and configuration entries have been removed."
     },
     "error": {
-      "invalid_confirmation": "Please type \"YES I WANT\"."
+      "invalid_confirmation": "Please type \"YES I WANT\".",
+      "confirmation_required": "Confirmation required"
     },
     "step": {
         "menu": {
@@ -117,6 +118,7 @@
           "menu_options": {
             "user": "User settings",
             "drinks": "Drink settings",
+            "free_marks": "Free marks",
             "cleanup": "Remove unused sensors",
             "delete": "Delete all entries",
             "finish": "Done"
@@ -141,6 +143,20 @@
             "edit": "Edit price",
             "currency": "Set currency",
             "back": "Back"
+          }
+        },
+        "free_marks": {
+          "title": "Free marks",
+          "description": "Free marks are booked to the free drinks user, not to regular users.",
+          "data": {
+            "enable_free_marks": "Enable free marks"
+          }
+        },
+        "free_marks_confirm": {
+          "title": "Disable free marks",
+          "description": "Type \"YES I WANT\" to confirm",
+          "data": {
+            "confirm": "Confirmation"
           }
         },
         "add_drink": {
@@ -233,6 +249,7 @@
         "action": {
           "user": "User settings",
           "drinks": "Drink settings",
+          "free_marks": "Free marks",
           "add": "Add drink",
           "remove": "Remove drink",
           "edit": "Edit price",
@@ -248,6 +265,13 @@
           "back": "Back"
         }
       }
+  },
+  "exceptions": {
+    "free_marks_disabled": "Free marks feature is disabled",
+    "comment_required": "Comment required",
+    "cash_user_missing": "Free drinks user missing",
+    "drink_unknown": "Unknown drink",
+    "cannot_remove_count": "Cannot remove count"
   },
   "services": {
     "add_drink": {
@@ -265,6 +289,14 @@
         "count": {
           "name": "Count",
           "description": "Number of drinks to add"
+        },
+        "free_mark": {
+          "name": "Free mark",
+          "description": "Book as free mark"
+        },
+        "comment": {
+          "name": "Comment",
+          "description": "Comment for free mark"
         }
       }
     },
@@ -283,6 +315,14 @@
         "count": {
           "name": "Count",
           "description": "Number of drinks to remove"
+        },
+        "free_mark": {
+          "name": "Free mark",
+          "description": "Book as free mark"
+        },
+        "comment": {
+          "name": "Comment",
+          "description": "Comment for free mark"
         }
       }
     },


### PR DESCRIPTION
## Summary
- support booking drinks as free marks with CSV logging
- add configuration option to enable free marks and auto-create localized cash user
- extend services and translations for free mark usage
- handle free mark options flow without errors
- ensure cash user entry is created when free marks are enabled and track counts on that user
- initialize free mark defaults during config flow so finishing setup succeeds
- fix cash user name to localized default based on Home Assistant language
- keep cash user entity IDs in English regardless of localization
- avoid errors when disabling free marks in options flow

## Testing
- `python -m py_compile custom_components/tally_list/const.py custom_components/tally_list/__init__.py custom_components/tally_list/config_flow.py custom_components/tally_list/sensor.py custom_components/tally_list/button.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689847002358832e9403098da8066754