### PR TITLE
Warn about sensor removal when disabling free marks

### DIFF
--- a/custom_components/tally_list/translations/de.json
+++ b/custom_components/tally_list/translations/de.json
@@ -154,7 +154,7 @@
         },
         "free_marks_confirm": {
           "title": "Freimarken deaktivieren",
-          "description": "Gib zur Bestätigung \"JA ICH WILL\" ein",
+          "description": "Dies entfernt alle Sensoren und Konfigurationen des Nutzers Freigetränke. Gib zur Bestätigung \"JA ICH WILL\" ein",
           "data": {
             "confirm": "Bestätigung"
           }

--- a/custom_components/tally_list/translations/en.json
+++ b/custom_components/tally_list/translations/en.json
@@ -154,7 +154,7 @@
         },
         "free_marks_confirm": {
           "title": "Disable free marks",
-          "description": "Type \"YES I WANT\" to confirm",
+          "description": "This removes all sensors and configuration of the Free Drinks user. Type \"YES I WANT\" to confirm",
           "data": {
             "confirm": "Confirmation"
           }


### PR DESCRIPTION
## Summary
- warn that disabling the Free Drinks user removes its sensors and configuration

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689863bd9b98832eadd2432864368cd5