### PR TITLE
Validate user in add_drink service

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -30,7 +30,7 @@ Beim ersten Einrichten wirst du nach verfügbaren Getränken gefragt. Alle Perso
 
 ### Dienste
 
-- `tally_list.add_drink`: erhöht die Anzahl eines Getränks für eine Person (Anzahl kann angegeben werden).
+- `tally_list.add_drink`: erhöht die Anzahl eines Getränks für eine Person (schlägt fehl, wenn die Person nicht existiert; Anzahl kann angegeben werden).
 - `tally_list.remove_drink`: verringert die Anzahl eines Getränks für eine Person (nie unter null; Anzahl kann angegeben werden).
 - `tally_list.adjust_count`: setzt die Anzahl eines Getränks auf einen bestimmten Wert.
 - `tally_list.reset_counters`: setzt alle Zähler für eine Person oder – ohne Angabe einer Person – für alle zurück.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ At initial setup you will be asked to enter available drinks. All persons with a
 
 ### Services
 
-- `tally_list.add_drink`: increment drink count for a person (optionally specify amount).
+- `tally_list.add_drink`: increment drink count for a person (fails if the person does not exist; optionally specify amount).
 - `tally_list.remove_drink`: decrement drink count for a person (never below zero; optionally specify amount).
 - `tally_list.adjust_count`: set a drink count to a specific value.
 - `tally_list.reset_counters`: reset all counters for a person or for everyone if no user is specified.

--- a/custom_components/tally_list/translations/de.json
+++ b/custom_components/tally_list/translations/de.json
@@ -271,6 +271,7 @@
     "comment_required": "Kommentar erforderlich",
     "cash_user_missing": "Freigetränke-Nutzer fehlt",
     "drink_unknown": "Unbekanntes Getränk",
+    "user_unknown": "Unbekannte Person",
     "cannot_remove_count": "Anzahl kann nicht entfernt werden"
   },
   "services": {

--- a/custom_components/tally_list/translations/en.json
+++ b/custom_components/tally_list/translations/en.json
@@ -266,13 +266,14 @@
         }
       }
   },
-  "exceptions": {
-    "free_marks_disabled": "Free marks feature is disabled",
-    "comment_required": "Comment required",
-    "cash_user_missing": "Free drinks user missing",
-    "drink_unknown": "Unknown drink",
-    "cannot_remove_count": "Cannot remove count"
-  },
+    "exceptions": {
+        "free_marks_disabled": "Free marks feature is disabled",
+        "comment_required": "Comment required",
+        "cash_user_missing": "Free drinks user missing",
+        "drink_unknown": "Unknown drink",
+        "user_unknown": "Unknown person",
+        "cannot_remove_count": "Cannot remove count"
+    },
   "services": {
     "add_drink": {
       "name": "Add drink",


### PR DESCRIPTION
## Summary
- raise error when adding drinks for unknown users
- document that add_drink fails for non-existent persons

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68986498dd04832e900fb5a95cca902c