### PR TITLE
Rename free marks to free drinks and move option

### DIFF
--- a/custom_components/tally_list/config_flow.py
+++ b/custom_components/tally_list/config_flow.py
@@ -22,7 +22,7 @@ from .const import (
     PRICE_LIST_USERS,
     get_price_list_user,
     CONF_CURRENCY,
-    CONF_ENABLE_FREE_MARKS,
+    CONF_ENABLE_FREE_DRINKS,
     CONF_CASH_USER_NAME,
     get_cash_user_name,
 )
@@ -61,7 +61,7 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._currency: str = "€"
         self._create_price_user: bool = False
         self._user_selected: bool = False
-        self._enable_free_marks: bool = False
+        self._enable_free_drinks: bool = False
         self._cash_user_name: str = get_cash_user_name(None)
 
     async def async_step_import(self, user_input=None):
@@ -74,14 +74,14 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._excluded_users = user_input.get(CONF_EXCLUDED_USERS, [])
         self._override_users = user_input.get(CONF_OVERRIDE_USERS, [])
         self._currency = user_input.get(CONF_CURRENCY, "€")
-        self._enable_free_marks = user_input.get(CONF_ENABLE_FREE_MARKS, False)
+        self._enable_free_drinks = user_input.get(CONF_ENABLE_FREE_DRINKS, False)
         self._cash_user_name = get_cash_user_name(
             getattr(self.hass.config, "language", None)
         )
         if CONF_CURRENCY not in user_input:
             user_input[CONF_CURRENCY] = self._currency
-        if CONF_ENABLE_FREE_MARKS not in user_input:
-            user_input[CONF_ENABLE_FREE_MARKS] = self._enable_free_marks
+        if CONF_ENABLE_FREE_DRINKS not in user_input:
+            user_input[CONF_ENABLE_FREE_DRINKS] = self._enable_free_drinks
         user_input[CONF_CASH_USER_NAME] = self._cash_user_name
         return self.async_create_entry(title=self._user, data=user_input)
 
@@ -133,8 +133,8 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     self._override_users = entry.data.get(CONF_OVERRIDE_USERS, [])
                     self._free_amount = float(entry.data.get(CONF_FREE_AMOUNT, 0.0))
                     self._currency = entry.data.get(CONF_CURRENCY, "€")
-                    self._enable_free_marks = entry.data.get(
-                        CONF_ENABLE_FREE_MARKS, False
+                    self._enable_free_drinks = entry.data.get(
+                        CONF_ENABLE_FREE_DRINKS, False
                     )
                     self._cash_user_name = get_cash_user_name(
                         getattr(self.hass.config, "language", None)
@@ -189,35 +189,35 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         schema = vol.Schema({vol.Required(CONF_CURRENCY, default=self._currency): str})
         return self.async_show_form(step_id="currency", data_schema=schema)
 
-    async def async_step_free_marks(self, user_input=None):
+    async def async_step_free_drinks(self, user_input=None):
         if user_input is not None:
-            enable = user_input[CONF_ENABLE_FREE_MARKS]
-            if self._enable_free_marks and not enable:
-                return await self.async_step_free_marks_confirm()
-            self._enable_free_marks = enable
+            enable = user_input[CONF_ENABLE_FREE_DRINKS]
+            if self._enable_free_drinks and not enable:
+                return await self.async_step_free_drinks_confirm()
+            self._enable_free_drinks = enable
             return await self.async_step_menu()
         schema = vol.Schema(
             {
                 vol.Required(
-                    CONF_ENABLE_FREE_MARKS, default=self._enable_free_marks
+                    CONF_ENABLE_FREE_DRINKS, default=self._enable_free_drinks
                 ): bool
             }
         )
         return self.async_show_form(
-            step_id="free_marks", data_schema=schema
+            step_id="free_drinks", data_schema=schema
         )
 
-    async def async_step_free_marks_confirm(self, user_input=None):
+    async def async_step_free_drinks_confirm(self, user_input=None):
         errors = {}
         if user_input is not None:
             confirmation = user_input.get("confirm", "").strip().upper()
             if confirmation in {"JA ICH WILL", "YES I WANT"}:
-                self._enable_free_marks = False
+                self._enable_free_drinks = False
                 return await self.async_step_menu()
             errors["base"] = "confirmation_required"
         schema = vol.Schema({vol.Required("confirm"): str})
         return self.async_show_form(
-            step_id="free_marks_confirm", data_schema=schema, errors=errors
+            step_id="free_drinks_confirm", data_schema=schema, errors=errors
         )
 
     async def async_step_exclude(self, user_input=None):
@@ -413,7 +413,7 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 CONF_EXCLUDED_USERS: self._excluded_users,
                 CONF_OVERRIDE_USERS: self._override_users,
                 CONF_CURRENCY: self._currency,
-                CONF_ENABLE_FREE_MARKS: self._enable_free_marks,
+                CONF_ENABLE_FREE_DRINKS: self._enable_free_drinks,
                 CONF_CASH_USER_NAME: self._cash_user_name,
             },
         )
@@ -424,7 +424,7 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self.hass.data[DOMAIN][CONF_EXCLUDED_USERS] = self._excluded_users
         self.hass.data[DOMAIN][CONF_OVERRIDE_USERS] = self._override_users
         self.hass.data[DOMAIN][CONF_CURRENCY] = self._currency
-        self.hass.data[DOMAIN][CONF_ENABLE_FREE_MARKS] = self._enable_free_marks
+        self.hass.data[DOMAIN][CONF_ENABLE_FREE_DRINKS] = self._enable_free_drinks
         self.hass.data[DOMAIN][CONF_CASH_USER_NAME] = self._cash_user_name
         if self._create_price_user:
             self.hass.async_create_task(
@@ -476,7 +476,7 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             ),
             None,
         )
-        if self._enable_free_marks:
+        if self._enable_free_drinks:
             if cash_entry is None:
                 self.hass.async_create_task(
                     self.hass.config_entries.flow.async_init(
@@ -488,7 +488,7 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             else:
                 cash_data = self.hass.data.get(DOMAIN, {}).get(cash_entry.entry_id)
                 if cash_data is not None:
-                    self.hass.data[DOMAIN]["free_mark_counts"] = cash_data.setdefault(
+                    self.hass.data[DOMAIN]["free_drink_counts"] = cash_data.setdefault(
                         "counts", {}
                     )
         elif cash_entry is not None:
@@ -500,8 +500,8 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self.hass.async_create_task(
                 self.hass.config_entries.async_remove(cash_entry.entry_id)
             )
-            self.hass.data[DOMAIN].pop("free_mark_counts", None)
-            self.hass.data[DOMAIN].pop("free_marks_ledger", None)
+            self.hass.data[DOMAIN].pop("free_drink_counts", None)
+            self.hass.data[DOMAIN].pop("free_drinks_ledger", None)
 
     @staticmethod
     @callback
@@ -519,7 +519,7 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
         self._excluded_users: list[str] = []
         self._override_users: list[str] = []
         self._currency: str = "€"
-        self._enable_free_marks: bool = False
+        self._enable_free_drinks: bool = False
         self._cash_user_name: str = get_cash_user_name(None)
 
     async def async_step_init(self, user_input=None):
@@ -532,8 +532,8 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
             self.hass.data.get(DOMAIN, {}).get(CONF_OVERRIDE_USERS, [])
         ).copy()
         self._currency = self.hass.data.get(DOMAIN, {}).get(CONF_CURRENCY, "€")
-        self._enable_free_marks = self.hass.data.get(DOMAIN, {}).get(
-            CONF_ENABLE_FREE_MARKS, False
+        self._enable_free_drinks = self.hass.data.get(DOMAIN, {}).get(
+            CONF_ENABLE_FREE_DRINKS, False
         )
         self._cash_user_name = get_cash_user_name(self.hass.config.language)
         return await self.async_step_menu()
@@ -544,7 +544,6 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
             menu_options=[
                 "user",
                 "drinks",
-                "free_marks",
                 "cleanup",
                 "delete",
                 "finish",
@@ -572,6 +571,7 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
                 "remove",
                 "edit",
                 "currency",
+                "free_drinks",
                 "back",
             ],
         )
@@ -598,34 +598,33 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
         schema = vol.Schema({vol.Required(CONF_CURRENCY, default=self._currency): str})
         return self.async_show_form(step_id="currency", data_schema=schema)
 
-    async def async_step_free_marks(self, user_input=None):
+    async def async_step_free_drinks(self, user_input=None):
         if user_input is not None:
-            enable = user_input[CONF_ENABLE_FREE_MARKS]
-            if self._enable_free_marks and not enable:
-                return await self.async_step_free_marks_confirm()
-            self._enable_free_marks = enable
-            return await self.async_step_menu()
+            enable = user_input[CONF_ENABLE_FREE_DRINKS]
+            if self._enable_free_drinks and not enable:
+                return await self.async_step_free_drinks_confirm()
+            self._enable_free_drinks = enable
+            return await self.async_step_drinks()
         schema = vol.Schema(
             {
                 vol.Required(
-                    CONF_ENABLE_FREE_MARKS, default=self._enable_free_marks
+                    CONF_ENABLE_FREE_DRINKS, default=self._enable_free_drinks
                 ): bool
             }
         )
-        return self.async_show_form(step_id="free_marks", data_schema=schema)
+        return self.async_show_form(step_id="free_drinks", data_schema=schema)
 
-    async def async_step_free_marks_confirm(self, user_input=None):
+    async def async_step_free_drinks_confirm(self, user_input=None):
         errors = {}
         if user_input is not None:
             confirmation = user_input.get("confirm", "").strip().upper()
             if confirmation in {"JA ICH WILL", "YES I WANT"}:
-                self._enable_free_marks = False
+                self._enable_free_drinks = False
                 return self.async_show_menu(
                     step_id="menu",
                     menu_options=[
                         "user",
                         "drinks",
-                        "free_marks",
                         "cleanup",
                         "delete",
                         "finish",
@@ -634,7 +633,7 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
             errors["base"] = "confirmation_required"
         schema = vol.Schema({vol.Required("confirm"): str})
         return self.async_show_form(
-            step_id="free_marks_confirm", data_schema=schema, errors=errors
+            step_id="free_drinks_confirm", data_schema=schema, errors=errors
         )
 
     async def async_step_exclude(self, user_input=None):
@@ -987,7 +986,7 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
             ),
             None,
         )
-        if self._enable_free_marks:
+        if self._enable_free_drinks:
             if cash_entry is None:
                 self.hass.async_create_task(
                     self.hass.config_entries.flow.async_init(
@@ -999,7 +998,7 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
             else:
                 cash_data = self.hass.data.get(DOMAIN, {}).get(cash_entry.entry_id)
                 if cash_data is not None:
-                    self.hass.data[DOMAIN]["free_mark_counts"] = cash_data.setdefault(
+                    self.hass.data[DOMAIN]["free_drink_counts"] = cash_data.setdefault(
                         "counts", {}
                     )
         elif cash_entry is not None:
@@ -1011,8 +1010,8 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
             self.hass.async_create_task(
                 self.hass.config_entries.async_remove(cash_entry.entry_id)
             )
-            self.hass.data[DOMAIN].pop("free_mark_counts", None)
-            self.hass.data[DOMAIN].pop("free_marks_ledger", None)
+            self.hass.data[DOMAIN].pop("free_drink_counts", None)
+            self.hass.data[DOMAIN].pop("free_drinks_ledger", None)
 
         for entry in self.hass.config_entries.async_entries(DOMAIN):
             data = {
@@ -1022,7 +1021,7 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
                 CONF_EXCLUDED_USERS: self._excluded_users,
                 CONF_OVERRIDE_USERS: self._override_users,
                 CONF_CURRENCY: self._currency,
-                CONF_ENABLE_FREE_MARKS: self._enable_free_marks,
+                CONF_ENABLE_FREE_DRINKS: self._enable_free_drinks,
                 CONF_CASH_USER_NAME: self._cash_user_name,
             }
             self.hass.config_entries.async_update_entry(entry, data=data)
@@ -1039,7 +1038,7 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
                 CONF_EXCLUDED_USERS: self._excluded_users,
                 CONF_OVERRIDE_USERS: self._override_users,
                 CONF_CURRENCY: self._currency,
-                CONF_ENABLE_FREE_MARKS: self._enable_free_marks,
+                CONF_ENABLE_FREE_DRINKS: self._enable_free_drinks,
                 CONF_CASH_USER_NAME: self._cash_user_name,
             },
         )

--- a/custom_components/tally_list/const.py
+++ b/custom_components/tally_list/const.py
@@ -9,12 +9,12 @@ CONF_EXCLUDED_USERS = "excluded_users"
 CONF_OVERRIDE_USERS = "override_users"
 CONF_CURRENCY = "currency"
 
-CONF_ENABLE_FREE_MARKS = "enable_free_marks"
+CONF_ENABLE_FREE_DRINKS = "enable_free_drinks"
 CONF_CASH_USER_NAME = "cash_user_name"
 
 ATTR_USER = "user"
 ATTR_DRINK = "drink"
-ATTR_FREE_MARK = "free_mark"
+ATTR_FREE_DRINK = "free_drink"
 ATTR_COMMENT = "comment"
 
 SERVICE_ADD_DRINK = "add_drink"

--- a/custom_components/tally_list/services.yaml
+++ b/custom_components/tally_list/services.yaml
@@ -22,13 +22,13 @@ add_drink:
         number:
           min: 1
           step: 1
-    free_mark:
-      description: Book as free mark
+    free_drink:
+      description: Book as free drink
       required: true
       selector:
         boolean:
     comment:
-      description: Comment for free mark
+      description: Comment for free drink
       required: false
       selector:
         text:
@@ -56,13 +56,13 @@ remove_drink:
         number:
           min: 1
           step: 1
-    free_mark:
-      description: Book as free mark
+    free_drink:
+      description: Book as free drink
       required: false
       selector:
         boolean:
     comment:
-      description: Comment for free mark
+      description: Comment for free drink
       required: false
       selector:
         text:

--- a/custom_components/tally_list/translations/de.json
+++ b/custom_components/tally_list/translations/de.json
@@ -118,7 +118,6 @@
           "menu_options": {
             "user": "Nutzereinstellungen",
             "drinks": "Getränkeeinstellungen",
-            "free_marks": "Freimarken",
             "cleanup": "Nicht mehr genutzte Sensoren entfernen",
             "delete": "Integration komplett entfernen",
             "finish": "Fertig"
@@ -142,18 +141,19 @@
             "remove": "Entfernen",
             "edit": "Bearbeiten",
             "currency": "Währung setzen",
+            "free_drinks": "Freigetränke",
             "back": "Zurück"
           }
         },
-        "free_marks": {
-          "title": "Freimarken",
-          "description": "Freimarken werden auf den Freigetränke-Nutzer gebucht, nicht auf normale Nutzer.",
+        "free_drinks": {
+          "title": "Freigetränke",
+          "description": "Freigetränke werden auf den Freigetränke-Nutzer gebucht, nicht auf normale Nutzer.",
           "data": {
-            "enable_free_marks": "Freimarken aktivieren"
+            "enable_free_drinks": "Freigetränke aktivieren"
           }
         },
-        "free_marks_confirm": {
-          "title": "Freimarken deaktivieren",
+        "free_drinks_confirm": {
+          "title": "Freigetränke deaktivieren",
           "description": "Dies entfernt alle Sensoren und Konfigurationen des Nutzers Freigetränke. Gib zur Bestätigung \"JA ICH WILL\" ein",
           "data": {
             "confirm": "Bestätigung"
@@ -249,7 +249,7 @@
         "action": {
           "user": "Nutzereinstellungen",
           "drinks": "Getränkeeinstellungen",
-          "free_marks": "Freimarken",
+          "free_drinks": "Freigetränke",
           "add": "Hinzufügen",
           "remove": "Entfernen",
           "edit": "Bearbeiten",
@@ -267,7 +267,7 @@
       }
     },
   "exceptions": {
-    "free_marks_disabled": "Freimarken sind deaktiviert",
+    "free_drinks_disabled": "Freigetränke sind deaktiviert",
     "comment_required": "Kommentar erforderlich",
     "cash_user_missing": "Freigetränke-Nutzer fehlt",
     "drink_unknown": "Unbekanntes Getränk",
@@ -291,13 +291,13 @@
           "name": "Anzahl",
           "description": "Anzahl der hinzuzufügenden Getränke"
         },
-        "free_mark": {
-          "name": "Freimarke",
-          "description": "Als Freimarke buchen"
+        "free_drink": {
+          "name": "Freigetränk",
+          "description": "Als Freigetränk buchen"
         },
         "comment": {
           "name": "Kommentar",
-          "description": "Kommentar für Freimarke"
+          "description": "Kommentar für Freigetränk"
         }
       }
     },
@@ -317,13 +317,13 @@
           "name": "Anzahl",
           "description": "Anzahl der zu entfernenden Getränke"
         },
-        "free_mark": {
-          "name": "Freimarke",
-          "description": "Als Freimarke buchen"
+        "free_drink": {
+          "name": "Freigetränk",
+          "description": "Als Freigetränk buchen"
         },
         "comment": {
           "name": "Kommentar",
-          "description": "Kommentar für Freimarke"
+          "description": "Kommentar für Freigetränk"
         }
       }
     },

--- a/custom_components/tally_list/translations/en.json
+++ b/custom_components/tally_list/translations/en.json
@@ -118,7 +118,6 @@
           "menu_options": {
             "user": "User settings",
             "drinks": "Drink settings",
-            "free_marks": "Free marks",
             "cleanup": "Remove unused sensors",
             "delete": "Delete all entries",
             "finish": "Done"
@@ -142,18 +141,19 @@
             "remove": "Remove drink",
             "edit": "Edit price",
             "currency": "Set currency",
+            "free_drinks": "Free drinks",
             "back": "Back"
           }
         },
-        "free_marks": {
-          "title": "Free marks",
-          "description": "Free marks are booked to the free drinks user, not to regular users.",
+        "free_drinks": {
+          "title": "Free drinks",
+          "description": "Free drinks are booked to the free drinks user, not to regular users.",
           "data": {
-            "enable_free_marks": "Enable free marks"
+            "enable_free_drinks": "Enable free drinks"
           }
         },
-        "free_marks_confirm": {
-          "title": "Disable free marks",
+        "free_drinks_confirm": {
+          "title": "Disable free drinks",
           "description": "This removes all sensors and configuration of the Free Drinks user. Type \"YES I WANT\" to confirm",
           "data": {
             "confirm": "Confirmation"
@@ -249,7 +249,7 @@
         "action": {
           "user": "User settings",
           "drinks": "Drink settings",
-          "free_marks": "Free marks",
+          "free_drinks": "Free drinks",
           "add": "Add drink",
           "remove": "Remove drink",
           "edit": "Edit price",
@@ -267,7 +267,7 @@
       }
   },
     "exceptions": {
-        "free_marks_disabled": "Free marks feature is disabled",
+        "free_drinks_disabled": "Free drinks feature is disabled",
         "comment_required": "Comment required",
         "cash_user_missing": "Free drinks user missing",
         "drink_unknown": "Unknown drink",
@@ -291,13 +291,13 @@
           "name": "Count",
           "description": "Number of drinks to add"
         },
-        "free_mark": {
-          "name": "Free mark",
-          "description": "Book as free mark"
+        "free_drink": {
+          "name": "Free drink",
+          "description": "Book as free drink"
         },
         "comment": {
           "name": "Comment",
-          "description": "Comment for free mark"
+          "description": "Comment for free drink"
         }
       }
     },
@@ -317,13 +317,13 @@
           "name": "Count",
           "description": "Number of drinks to remove"
         },
-        "free_mark": {
-          "name": "Free mark",
-          "description": "Book as free mark"
+        "free_drink": {
+          "name": "Free drink",
+          "description": "Book as free drink"
         },
         "comment": {
           "name": "Comment",
-          "description": "Comment for free mark"
+          "description": "Comment for free drink"
         }
       }
     },


### PR DESCRIPTION
## Summary
- rename "free marks" concept to "free drinks" across constants, services, and translations
- relocate free drinks configuration under drink settings menu

## Testing
- `python -m json.tool custom_components/tally_list/translations/de.json`
- `python -m json.tool custom_components/tally_list/translations/en.json`
- `python -m py_compile custom_components/tally_list/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6898671ee6dc832e9a5d440105d82fb6