### PR TITLE
Assign free drink feed sensors to cash user

### DIFF
--- a/custom_components/tally_list/sensor.py
+++ b/custom_components/tally_list/sensor.py
@@ -54,7 +54,11 @@ async def async_setup_entry(
     data.setdefault("sensors", []).extend(sensors)
     async_add_entities(sensors)
 
-    if "feed_add_entities" not in hass.data[DOMAIN]:
+    cash_name = hass.data.get(DOMAIN, {}).get(CONF_CASH_USER_NAME, "")
+    if (
+        user.strip().lower() == cash_name.strip().lower()
+        and "feed_add_entities" not in hass.data[DOMAIN]
+    ):
         hass.data[DOMAIN]["feed_add_entities"] = async_add_entities
         hass.data[DOMAIN]["feed_entry_id"] = entry.entry_id
         feed_sensors: dict[int, FreeDrinkFeedSensor] = {}


### PR DESCRIPTION
## Summary
- ensure `sensor.free_drink_feed_XXXX` entities are created only for the Freigetränke (cash) user

## Testing
- `python -m py_compile custom_components/tally_list/sensor.py`
- `ruff check custom_components/tally_list/sensor.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689878ae327c832e835f25ebef044d53