### PR TITLE
Assign free drink feed sensors to cash user

### DIFF
--- a/custom_components/tally_list/__init__.py
+++ b/custom_components/tally_list/__init__.py
@@ -212,8 +212,14 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                 await sensor.async_update_state()
             else:
                 add_entities = hass.data[DOMAIN].get("feed_add_entities")
-                if add_entities is not None:
-                    sensor = FreeDrinkFeedSensor(hass, year)
+                feed_entry_id = hass.data[DOMAIN].get("feed_entry_id")
+                entry = (
+                    hass.config_entries.async_get_entry(feed_entry_id)
+                    if feed_entry_id is not None
+                    else None
+                )
+                if add_entities is not None and entry is not None:
+                    sensor = FreeDrinkFeedSensor(hass, entry, year)
                     feed_sensors[year] = sensor
                     add_entities([sensor])
             hass.bus.async_fire(
@@ -285,8 +291,14 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                 await sensor.async_update_state()
             else:
                 add_entities = hass.data[DOMAIN].get("feed_add_entities")
-                if add_entities is not None:
-                    sensor = FreeDrinkFeedSensor(hass, year)
+                feed_entry_id = hass.data[DOMAIN].get("feed_entry_id")
+                entry = (
+                    hass.config_entries.async_get_entry(feed_entry_id)
+                    if feed_entry_id is not None
+                    else None
+                )
+                if add_entities is not None and entry is not None:
+                    sensor = FreeDrinkFeedSensor(hass, entry, year)
                     feed_sensors[year] = sensor
                     add_entities([sensor])
             hass.bus.async_fire(


### PR DESCRIPTION
## Summary
- ensure `sensor.free_drink_feed_XXXX` entities are created only for the Freigetränke (cash) user
- provide unique IDs and register feed sensors under the cash user's config entry

## Testing
- `python -m py_compile custom_components/tally_list/sensor.py custom_components/tally_list/__init__.py`
- `ruff check custom_components/tally_list/sensor.py custom_components/tally_list/__init__.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689878ae327c832e835f25ebef044d53