### PR TITLE
Allow admins to set PINs for other users

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -11,7 +11,7 @@ Diese benutzerdefinierte Integration für [Home Assistant](https://www.home-assi
 - Sensoren für Getränkezählungen, Getränkepreise, einen Freibetrag und den Gesamtbetrag pro Person.
 - Button-Entität zum Zurücksetzen aller Zähler einer Person; nur Nutzer mit Override-Rechten („Tally Admins") dürfen sie verwenden.
 - Konfigurierbares Währungssymbol (Standard: €).
-- Dienste zum Hinzufügen, Entfernen, Anpassen, Zurücksetzen, Exportieren von Zählern und zum Setzen persönlicher PINs.
+- Dienste zum Hinzufügen, Entfernen, Anpassen, Zurücksetzen, Exportieren von Zählern und zur Verwaltung persönlicher PINs (Tally-Admins können PINs für andere Nutzer setzen).
 - Zähler können beim Entfernen eines Getränks nicht unter null fallen.
 - Möglichkeit, Personen vom automatischen Import auszuschließen.
 - Vergabe von Override-Rechten an ausgewählte Nutzer, damit sie für alle Getränke zählen können.
@@ -37,7 +37,7 @@ Beim ersten Einrichten wirst du nach verfügbaren Getränken gefragt. Alle Perso
 - `tally_list.adjust_count`: setzt die Anzahl eines Getränks auf einen bestimmten Wert.
 - `tally_list.reset_counters`: setzt alle Zähler für eine Person oder – ohne Angabe einer Person – für alle zurück.
 - `tally_list.export_csv`: exportiert alle `_amount_due`-Sensoren als CSV-Dateien (`daily`, `weekly`, `monthly` oder `manual`), gespeichert unter `/config/backup/tally_list/<type>/`.
-- `tally_list.set_pin`: setzt oder entfernt deine persönliche PIN für öffentliche Geräte.
+- `tally_list.set_pin`: setzt oder entfernt eine persönliche PIN für öffentliche Geräte (Admins können PINs für andere Nutzer setzen).
 
 ### Reset-Schalter
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This custom integration for [Home Assistant](https://www.home-assistant.io/) is 
 - Sensor entities for drink counts, drink prices, a free amount, and the total amount due per person.
 - Button entity to reset a person's counters; only users with override permissions ("Tally Admins") can use it.
 - Configurable currency symbol (defaults to €).
-- Services to add, remove, adjust, reset and export tallies, and set personal PINs.
+- Services to add, remove, adjust, reset and export tallies, and manage personal PINs (Tally Admins can set PINs for other users).
 - Counters cannot go below zero when removing drinks.
 - Option to exclude persons from automatic import.
 - Grant override permissions to selected users so they can tally drinks for everyone.
@@ -37,7 +37,7 @@ At initial setup you will be asked to enter available drinks. All persons with a
 - `tally_list.adjust_count`: set a drink count to a specific value.
 - `tally_list.reset_counters`: reset all counters for a person or for everyone if no user is specified.
 - `tally_list.export_csv`: export all `_amount_due` sensors to CSV files (`daily`, `weekly`, `monthly`, or `manual`) saved under `/config/backup/tally_list/<type>/`.
-- `tally_list.set_pin`: set or clear your personal PIN required for public devices.
+- `tally_list.set_pin`: set or clear a personal PIN required for public devices (admins can set PINs for others).
 
 ### Reset Button
 

--- a/custom_components/tally_list/services.yaml
+++ b/custom_components/tally_list/services.yaml
@@ -156,8 +156,13 @@ export_csv:
           step: 1
 set_pin:
   name: Set PIN
-  description: Set or clear your personal PIN
+  description: Set or clear a personal PIN
   fields:
+    user:
+      description: Person name (admin only)
+      required: false
+      selector:
+        text:
     pin:
       description: New PIN (leave empty to clear)
       required: false

--- a/custom_components/tally_list/translations/de.json
+++ b/custom_components/tally_list/translations/de.json
@@ -439,8 +439,12 @@
     },
     "set_pin": {
       "name": "PIN setzen",
-      "description": "Persönliche PIN setzen oder löschen",
+      "description": "Persönliche PIN für eine Person setzen oder löschen",
       "fields": {
+        "user": {
+          "name": "Person",
+          "description": "Personenname (nur für Tally-Admins)"
+        },
         "pin": {
           "name": "PIN",
           "description": "Neue PIN (leer lassen zum Löschen)"

--- a/custom_components/tally_list/translations/en.json
+++ b/custom_components/tally_list/translations/en.json
@@ -439,8 +439,12 @@
     },
     "set_pin": {
       "name": "Set PIN",
-      "description": "Set or clear your personal PIN",
+      "description": "Set or clear a personal PIN",
       "fields": {
+        "user": {
+          "name": "Person",
+          "description": "Person name (admin only)"
+        },
         "pin": {
           "name": "PIN",
           "description": "New PIN (leave empty to clear)"


### PR DESCRIPTION
## Summary
- permit specifying a target user when calling `tally_list.set_pin`
- restrict setting PINs for other users to Tally Admins only
- document new `user` option and update translations

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b34846cfb4832ea025c05ad382992e