### PR TITLE
docs: update websocket api examples

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -67,23 +67,29 @@ Name des Freigetränke-Benutzers angepasst werden.
 Der WebSocket-Befehl `tally_list/get_admins` gibt alle Benutzer mit Override-Rechten zurück und kann aus dem Home-Assistant-Frontend oder einem externen Client aufgerufen werden. Der Befehl erfordert einen authentifizierten Home-Assistant-Benutzer.
 
 ```js
-await this.hass.connection.sendMessagePromise({ type: "tally_list/get_admins" });
+await this.hass.callWS({ type: "tally_list/get_admins" });
 ```
 
 Beispielantwort:
 
 ```json
-{"id":42,"type":"result","success":true,"result":{"admins":["tablet_dashboard","Test","Test 2"]}}
+{"admins":["tablet_dashboard","Test","Test 2"]}
 ```
 
 Der Befehl `tally_list/is_public_device` liefert zurück, ob der authentifizierte Benutzer als öffentliches Gerät konfiguriert ist:
 
 ```js
-await this.hass.connection.sendMessagePromise({ type: "tally_list/is_public_device" });
+await this.hass.callWS({ type: "tally_list/is_public_device" });
 ```
 
-Beispielantwort:
+Beispielantwort, wenn der Benutzer als öffentliches Gerät konfiguriert ist:
 
 ```json
-{"id":42,"type":"result","success":true,"result":{"is_public":true}}
+{"is_public": true}
+```
+
+Beispielantwort für einen normalen Benutzer:
+
+```json
+{"is_public": false}
 ```

--- a/README.md
+++ b/README.md
@@ -67,23 +67,29 @@ from the integration options.
 The WebSocket command `tally_list/get_admins` returns all users that currently have override permissions and can be called from the Home Assistant frontend or an external client. The command requires an authenticated Home Assistant user.
 
 ```js
-await this.hass.connection.sendMessagePromise({ type: "tally_list/get_admins" });
+await this.hass.callWS({ type: "tally_list/get_admins" });
 ```
 
 Example response:
 
 ```json
-{"id":42,"type":"result","success":true,"result":{"admins":["tablet_dashboard","Test","Test 2"]}}
+{"admins":["tablet_dashboard","Test","Test 2"]}
 ```
 
 The command `tally_list/is_public_device` returns whether the authenticated user is configured as a public device:
 
 ```js
-await this.hass.connection.sendMessagePromise({ type: "tally_list/is_public_device" });
+await this.hass.callWS({ type: "tally_list/is_public_device" });
 ```
 
-Example response:
+Example response if the user is configured as a public device:
 
 ```json
-{"id":42,"type":"result","success":true,"result":{"is_public":true}}
+{"is_public": true}
+```
+
+Example response for a regular user:
+
+```json
+{"is_public": false}
 ```


### PR DESCRIPTION
## Summary
- clarify WebSocket API usage by switching to `hass.callWS`
- document both public and regular device responses for `tally_list/is_public_device`

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b34b316a30832e87beaf9181a8b866