### PR TITLE
Enforce four-digit PIN for set_pin service

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -37,7 +37,7 @@ Beim ersten Einrichten wirst du nach verfügbaren Getränken gefragt. Alle Perso
 - `tally_list.adjust_count`: setzt die Anzahl eines Getränks auf einen bestimmten Wert.
 - `tally_list.reset_counters`: setzt alle Zähler für eine Person oder – ohne Angabe einer Person – für alle zurück.
 - `tally_list.export_csv`: exportiert alle `_amount_due`-Sensoren als CSV-Dateien (`daily`, `weekly`, `monthly` oder `manual`), gespeichert unter `/config/backup/tally_list/<type>/`.
-- `tally_list.set_pin`: setzt oder entfernt eine persönliche PIN für öffentliche Geräte (Admins können PINs für andere Nutzer setzen).
+- `tally_list.set_pin`: setzt oder entfernt eine persönliche vierstellige PIN aus Ziffern für öffentliche Geräte (Admins können PINs für andere Nutzer setzen).
 
 ### Reset-Schalter
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ At initial setup you will be asked to enter available drinks. All persons with a
 - `tally_list.adjust_count`: set a drink count to a specific value.
 - `tally_list.reset_counters`: reset all counters for a person or for everyone if no user is specified.
 - `tally_list.export_csv`: export all `_amount_due` sensors to CSV files (`daily`, `weekly`, `monthly`, or `manual`) saved under `/config/backup/tally_list/<type>/`.
-- `tally_list.set_pin`: set or clear a personal PIN required for public devices (admins can set PINs for others).
+- `tally_list.set_pin`: set or clear a personal 4-digit numeric PIN required for public devices (admins can set PINs for others).
 
 ### Reset Button
 

--- a/custom_components/tally_list/__init__.py
+++ b/custom_components/tally_list/__init__.py
@@ -167,7 +167,12 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
         pin = call.data.get(ATTR_PIN)
         user_pins = hass.data[DOMAIN].setdefault(CONF_USER_PINS, {})
-        if pin:
+        if pin is not None and pin != "":
+            pin = str(pin)
+            if not re.fullmatch(r"\d{4}", pin):
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN, translation_key="invalid_pin"
+                )
             user_pins[target_user] = pin
         else:
             user_pins.pop(target_user, None)

--- a/custom_components/tally_list/services.yaml
+++ b/custom_components/tally_list/services.yaml
@@ -156,7 +156,7 @@ export_csv:
           step: 1
 set_pin:
   name: Set PIN
-  description: Set or clear a personal PIN
+  description: Set or clear a personal 4-digit PIN
   fields:
     user:
       description: Person name (admin only)
@@ -164,7 +164,8 @@ set_pin:
       selector:
         text:
     pin:
-      description: New PIN (leave empty to clear)
+      description: New 4-digit PIN (leave empty to clear)
       required: false
       selector:
         text:
+          pattern: "^[0-9]{4}$"

--- a/custom_components/tally_list/translations/de.json
+++ b/custom_components/tally_list/translations/de.json
@@ -320,7 +320,8 @@
     "cash_user_missing": "Freigetränke-Nutzer fehlt",
     "drink_unknown": "Unbekanntes Getränk",
     "user_unknown": "Unbekannte Person",
-    "cannot_remove_count": "Anzahl kann nicht entfernt werden"
+    "cannot_remove_count": "Anzahl kann nicht entfernt werden",
+    "invalid_pin": "PIN muss genau vier Ziffern haben"
   },
   "services": {
     "add_drink": {
@@ -439,7 +440,7 @@
     },
     "set_pin": {
       "name": "PIN setzen",
-      "description": "Persönliche PIN für eine Person setzen oder löschen",
+      "description": "Persönliche vierstellige PIN für eine Person setzen oder löschen",
       "fields": {
         "user": {
           "name": "Person",
@@ -447,7 +448,7 @@
         },
         "pin": {
           "name": "PIN",
-          "description": "Neue PIN (leer lassen zum Löschen)"
+          "description": "Neue vierstellige PIN (leer lassen zum Löschen)"
         }
       }
     }

--- a/custom_components/tally_list/translations/en.json
+++ b/custom_components/tally_list/translations/en.json
@@ -320,7 +320,8 @@
     "cash_user_missing": "Free drinks user missing",
     "drink_unknown": "Unknown drink",
     "user_unknown": "Unknown person",
-    "cannot_remove_count": "Cannot remove count"
+    "cannot_remove_count": "Cannot remove count",
+    "invalid_pin": "PIN must consist of exactly four digits"
   },
   "services": {
     "add_drink": {
@@ -439,7 +440,7 @@
     },
     "set_pin": {
       "name": "Set PIN",
-      "description": "Set or clear a personal PIN",
+      "description": "Set or clear a personal 4-digit PIN",
       "fields": {
         "user": {
           "name": "Person",
@@ -447,7 +448,7 @@
         },
         "pin": {
           "name": "PIN",
-          "description": "New PIN (leave empty to clear)"
+          "description": "New 4-digit PIN (leave empty to clear)"
         }
       }
     }


### PR DESCRIPTION
## Summary
- Require set_pin service to accept only four-digit numeric PINs
- Document four-digit PIN requirement in services and README
- Add localized error messages for invalid PINs

## Testing
- `python -m py_compile custom_components/tally_list/__init__.py custom_components/tally_list/const.py`
- `python -m json.tool custom_components/tally_list/translations/en.json`
- `python -m json.tool custom_components/tally_list/translations/de.json`
- `python - <<'PY'
import yaml
with open('custom_components/tally_list/services.yaml') as f:
    yaml.safe_load(f)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b350d2c270832eb008ea9a5e1c86ec