### PR TITLE
feat: add websocket login

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -93,3 +93,21 @@ Beispielantwort für einen normalen Benutzer:
 ```json
 {"is_public": false}
 ```
+
+Öffentliche Geräte können einen Benutzer einmalig über den Befehl `tally_list/login` mit seiner PIN authentifizieren, sodass bei späteren Dienstaufrufen der Parameter `pin` nicht mehr benötigt wird:
+
+```js
+await this.hass.callWS({ type: "tally_list/login", user: "Alice", pin: "1234" });
+```
+
+Beispielantwort bei Erfolg:
+
+```json
+{"success": true}
+```
+
+Zum Beenden der Sitzung kann `tally_list/logout` aufgerufen werden:
+
+```js
+await this.hass.callWS({ type: "tally_list/logout" });
+```

--- a/README.md
+++ b/README.md
@@ -93,3 +93,21 @@ Example response for a regular user:
 ```json
 {"is_public": false}
 ```
+
+Public devices can authenticate a user once via the `tally_list/login` command so that subsequent service calls no longer need the `pin` parameter:
+
+```js
+await this.hass.callWS({ type: "tally_list/login", user: "Alice", pin: "1234" });
+```
+
+Example success response:
+
+```json
+{"success": true}
+```
+
+To end the session call `tally_list/logout`:
+
+```js
+await this.hass.callWS({ type: "tally_list/logout" });
+```

--- a/custom_components/tally_list/__init__.py
+++ b/custom_components/tally_list/__init__.py
@@ -75,6 +75,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         override_users = hass.data.get(DOMAIN, {}).get(CONF_OVERRIDE_USERS, [])
         public_devices = hass.data.get(DOMAIN, {}).get(CONF_PUBLIC_DEVICES, [])
         user_pins = hass.data.get(DOMAIN, {}).get(CONF_USER_PINS, {})
+        sessions = hass.data.get(DOMAIN, {}).get("sessions", {})
         person_name = None
         for state in hass.states.async_all("person"):
             if state.attributes.get("user_id") == hass_user.id:
@@ -85,6 +86,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         if person_name in public_devices and target_user:
             user_pin = user_pins.get(target_user)
             if user_pin and call.data.get(ATTR_PIN) == user_pin:
+                return
+            if sessions.get(user_id) == target_user:
                 return
         if target_user is None:
             raise Unauthorized

--- a/custom_components/tally_list/websocket.py
+++ b/custom_components/tally_list/websocket.py
@@ -7,7 +7,12 @@ from homeassistant.components import websocket_api
 from homeassistant.exceptions import Unauthorized
 import voluptuous as vol
 
-from .const import DOMAIN, CONF_OVERRIDE_USERS, CONF_PUBLIC_DEVICES
+from .const import (
+    DOMAIN,
+    CONF_OVERRIDE_USERS,
+    CONF_PUBLIC_DEVICES,
+    CONF_USER_PINS,
+)
 
 
 @websocket_api.websocket_command({vol.Required("type"): f"{DOMAIN}/get_admins"})
@@ -46,7 +51,56 @@ async def websocket_is_public_device(
     connection.send_result(msg["id"], {"is_public": person_name in public_devices})
 
 
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): f"{DOMAIN}/login",
+        vol.Required("user"): str,
+        vol.Required("pin"): str,
+    }
+)
+@websocket_api.async_response
+async def websocket_login(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict,
+) -> None:
+    """Validate a user's PIN and create a login session."""
+    if connection.user is None:
+        raise Unauthorized
+
+    user_pins = hass.data.get(DOMAIN, {}).get(CONF_USER_PINS, {})
+    sessions = hass.data.setdefault(DOMAIN, {}).setdefault("sessions", {})
+
+    pin = str(msg["pin"])
+    user = msg["user"]
+    success = user_pins.get(user) == pin
+
+    if success:
+        sessions[connection.user.id] = user
+
+    connection.send_result(msg["id"], {"success": success})
+
+
+@websocket_api.websocket_command({vol.Required("type"): f"{DOMAIN}/logout"})
+@websocket_api.async_response
+async def websocket_logout(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict,
+) -> None:
+    """Clear a previously created login session."""
+    if connection.user is None:
+        raise Unauthorized
+
+    sessions = hass.data.get(DOMAIN, {}).get("sessions", {})
+    sessions.pop(connection.user.id, None)
+
+    connection.send_result(msg["id"], {"success": True})
+
+
 async def async_register(hass: HomeAssistant) -> None:
     """Register Tally List WebSocket commands."""
     websocket_api.async_register_command(hass, websocket_get_admins)
     websocket_api.async_register_command(hass, websocket_is_public_device)
+    websocket_api.async_register_command(hass, websocket_login)
+    websocket_api.async_register_command(hass, websocket_logout)


### PR DESCRIPTION
## Summary
- add websocket commands to login/logout users with a PIN and keep a session for public devices
- allow _verify_permissions to accept logged-in sessions instead of per-call PIN
- document login/logout websocket API

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b35aa27a64832e8e091a7f50d07e9c