### PR TITLE
Add login/logout WebSocket commands for public devices

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -93,3 +93,21 @@ Beispielantwort für einen normalen Benutzer:
 ```json
 {"is_public": false}
 ```
+
+Öffentliche Geräte können einen Benutzer einmalig über den Befehl `tally_list/login` authentifizieren, damit nachfolgende Dienstaufrufe keinen `pin`-Parameter mehr benötigen:
+
+```js
+await this.hass.callWS({ type: "tally_list/login", user: "Alice", pin: "1234" });
+```
+
+Beispielantwort bei Erfolg:
+
+```json
+{"success": true}
+```
+
+Zum Beenden der Sitzung `tally_list/logout` aufrufen:
+
+```js
+await this.hass.callWS({ type: "tally_list/logout" });
+```

--- a/README.md
+++ b/README.md
@@ -93,3 +93,21 @@ Example response for a regular user:
 ```json
 {"is_public": false}
 ```
+
+Public devices can authenticate a user once via the `tally_list/login` command so that subsequent service calls no longer need the `pin` parameter:
+
+```js
+await this.hass.callWS({ type: "tally_list/login", user: "Alice", pin: "1234" });
+```
+
+Example success response:
+
+```json
+{"success": true}
+```
+
+To end the session call `tally_list/logout`:
+
+```js
+await this.hass.callWS({ type: "tally_list/logout" });
+```

--- a/custom_components/tally_list/__init__.py
+++ b/custom_components/tally_list/__init__.py
@@ -62,6 +62,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             CONF_CASH_USER_NAME: get_cash_user_name(hass.config.language),
             "free_drink_counts": {},
             "free_drinks_ledger": 0.0,
+            "logins": {},
         },
     )
 
@@ -75,6 +76,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         override_users = hass.data.get(DOMAIN, {}).get(CONF_OVERRIDE_USERS, [])
         public_devices = hass.data.get(DOMAIN, {}).get(CONF_PUBLIC_DEVICES, [])
         user_pins = hass.data.get(DOMAIN, {}).get(CONF_USER_PINS, {})
+        logins = hass.data.get(DOMAIN, {}).get("logins", {})
         person_name = None
         for state in hass.states.async_all("person"):
             if state.attributes.get("user_id") == hass_user.id:
@@ -84,7 +86,10 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             return
         if person_name in public_devices and target_user:
             user_pin = user_pins.get(target_user)
-            if user_pin and call.data.get(ATTR_PIN) == user_pin:
+            if user_pin and (
+                call.data.get(ATTR_PIN) == user_pin
+                or logins.get(user_id) == target_user
+            ):
                 return
         if target_user is None:
             raise Unauthorized

--- a/custom_components/tally_list/websocket.py
+++ b/custom_components/tally_list/websocket.py
@@ -7,7 +7,12 @@ from homeassistant.components import websocket_api
 from homeassistant.exceptions import Unauthorized
 import voluptuous as vol
 
-from .const import DOMAIN, CONF_OVERRIDE_USERS, CONF_PUBLIC_DEVICES
+from .const import (
+    DOMAIN,
+    CONF_OVERRIDE_USERS,
+    CONF_PUBLIC_DEVICES,
+    CONF_USER_PINS,
+)
 
 
 @websocket_api.websocket_command({vol.Required("type"): f"{DOMAIN}/get_admins"})
@@ -46,7 +51,61 @@ async def websocket_is_public_device(
     connection.send_result(msg["id"], {"is_public": person_name in public_devices})
 
 
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): f"{DOMAIN}/login",
+        vol.Required("user"): str,
+        vol.Required("pin"): str,
+    }
+)
+@websocket_api.async_response
+async def websocket_login(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict,
+) -> None:
+    """Authenticate a user on a public device using a PIN."""
+    if connection.user is None:
+        raise Unauthorized
+
+    person_name: str | None = None
+    for state in hass.states.async_all("person"):
+        if state.attributes.get("user_id") == connection.user.id:
+            person_name = state.name
+            break
+
+    public_devices = hass.data.get(DOMAIN, {}).get(CONF_PUBLIC_DEVICES, [])
+    user_pins = hass.data.get(DOMAIN, {}).get(CONF_USER_PINS, {})
+    if person_name not in public_devices:
+        raise Unauthorized
+
+    if user_pins.get(msg["user"]) == str(msg["pin"]):
+        hass.data[DOMAIN].setdefault("logins", {})[
+            connection.user.id
+        ] = msg["user"]
+        connection.send_result(msg["id"], {"success": True})
+    else:
+        connection.send_result(msg["id"], {"success": False})
+
+
+@websocket_api.websocket_command({vol.Required("type"): f"{DOMAIN}/logout"})
+@websocket_api.async_response
+async def websocket_logout(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict,
+) -> None:
+    """End a previously authenticated session on a public device."""
+    if connection.user is None:
+        raise Unauthorized
+
+    hass.data.get(DOMAIN, {}).get("logins", {}).pop(connection.user.id, None)
+    connection.send_result(msg["id"], {"success": True})
+
+
 async def async_register(hass: HomeAssistant) -> None:
     """Register Tally List WebSocket commands."""
     websocket_api.async_register_command(hass, websocket_get_admins)
     websocket_api.async_register_command(hass, websocket_is_public_device)
+    websocket_api.async_register_command(hass, websocket_login)
+    websocket_api.async_register_command(hass, websocket_logout)


### PR DESCRIPTION
## Summary
- Allow public devices to authenticate a user once using `tally_list/login`
- Add session tracking so logged-in public devices no longer need to send a PIN with each service call
- Provide a logout command and update documentation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b363f52a90832eb482931ad69f8464