### PR TITLE
Include iterations in hashed PIN format

### DIFF
--- a/custom_components/tally_list/security.py
+++ b/custom_components/tally_list/security.py
@@ -10,22 +10,41 @@ PBKDF2_ITERATIONS = 100_000
 def hash_pin(pin: str) -> str:
     """Hash a PIN using PBKDF2 with a random salt.
 
-    The returned value is formatted as ``<salt>$<hash>`` where both parts are
-    hex encoded.
+    The returned value is formatted as ``<iterations>$<salt>$<hash>`` where all
+    parts are hex encoded.
     """
     salt = os.urandom(16)
     key = hashlib.pbkdf2_hmac("sha256", pin.encode(), salt, PBKDF2_ITERATIONS)
-    return f"{salt.hex()}${key.hex()}"
+    return f"{PBKDF2_ITERATIONS}${salt.hex()}${key.hex()}"
 
 
 def verify_pin(pin: str, stored: str) -> bool:
-    """Verify a PIN against a stored hash."""
+    """Verify a PIN against a stored hash.
+
+    Supports the current ``<iterations>$<salt>$<hash>`` format as well as the
+    legacy ``<salt>$<hash>`` format which assumes ``PBKDF2_ITERATIONS``
+    iterations.
+    """
     if "$" not in stored:
         return False
-    salt_hex, hashed = stored.split("$", 1)
+
+    parts = stored.split("$")
+    if len(parts) == 2:
+        salt_hex, hashed = parts
+        iterations = PBKDF2_ITERATIONS
+    elif len(parts) == 3:
+        iterations_hex, salt_hex, hashed = parts
+        try:
+            iterations = int(iterations_hex)
+        except ValueError:
+            return False
+    else:
+        return False
+
     try:
         salt = bytes.fromhex(salt_hex)
     except ValueError:
         return False
-    key = hashlib.pbkdf2_hmac("sha256", pin.encode(), salt, PBKDF2_ITERATIONS)
+
+    key = hashlib.pbkdf2_hmac("sha256", pin.encode(), salt, iterations)
     return hmac.compare_digest(key.hex(), hashed)

--- a/custom_components/tally_list/websocket.py
+++ b/custom_components/tally_list/websocket.py
@@ -13,7 +13,7 @@ from .const import (
     CONF_PUBLIC_DEVICES,
     CONF_USER_PINS,
 )
-from .security import verify_pin
+from .security import hash_pin, verify_pin
 
 
 @websocket_api.websocket_command({vol.Required("type"): f"{DOMAIN}/get_admins"})
@@ -82,6 +82,9 @@ async def websocket_login(
 
     stored_pin = user_pins.get(msg["user"])
     if stored_pin and verify_pin(str(msg["pin"]), stored_pin):
+        if stored_pin.count("$") == 1:
+            user_pins[msg["user"]] = hash_pin(str(msg["pin"]))
+            await hass.data[DOMAIN]["pins_store"].async_save(user_pins)
         hass.data[DOMAIN].setdefault("logins", {})[
             connection.user.id
         ] = msg["user"]


### PR DESCRIPTION
## Summary
- include PBKDF2 iteration count in hashed PIN format
- parse iteration count when verifying and support legacy hashes
- migrate stored PINs to new hash format on use

## Testing
- `python -m py_compile custom_components/tally_list/security.py custom_components/tally_list/__init__.py custom_components/tally_list/websocket.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b752f18c8c832e90f10e1df21a39e5