### PR TITLE
Remove legacy PIN compatibility

### DIFF
--- a/custom_components/tally_list/__init__.py
+++ b/custom_components/tally_list/__init__.py
@@ -102,9 +102,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                 and verify_pin(str(provided_pin), user_pin)
             )
             if user_pin and (verified or logins.get(user_id) == target_user):
-                if verified and user_pin.count("$") == 1:
-                    user_pins[target_user] = hash_pin(str(provided_pin))
-                    await hass.data[DOMAIN]["pins_store"].async_save(user_pins)
                 return
         if target_user is None:
             raise Unauthorized

--- a/custom_components/tally_list/security.py
+++ b/custom_components/tally_list/security.py
@@ -19,29 +19,14 @@ def hash_pin(pin: str) -> str:
 
 
 def verify_pin(pin: str, stored: str) -> bool:
-    """Verify a PIN against a stored hash.
-
-    Supports the current ``<iterations>$<salt>$<hash>`` format as well as the
-    legacy ``<salt>$<hash>`` format which assumes ``PBKDF2_ITERATIONS``
-    iterations.
-    """
-    if "$" not in stored:
-        return False
-
+    """Verify a PIN against a stored hash."""
     parts = stored.split("$")
-    if len(parts) == 2:
-        salt_hex, hashed = parts
-        iterations = PBKDF2_ITERATIONS
-    elif len(parts) == 3:
-        iterations_hex, salt_hex, hashed = parts
-        try:
-            iterations = int(iterations_hex)
-        except ValueError:
-            return False
-    else:
+    if len(parts) != 3:
         return False
 
+    iterations_hex, salt_hex, hashed = parts
     try:
+        iterations = int(iterations_hex)
         salt = bytes.fromhex(salt_hex)
     except ValueError:
         return False

--- a/custom_components/tally_list/websocket.py
+++ b/custom_components/tally_list/websocket.py
@@ -13,7 +13,7 @@ from .const import (
     CONF_PUBLIC_DEVICES,
     CONF_USER_PINS,
 )
-from .security import hash_pin, verify_pin
+from .security import verify_pin
 
 
 @websocket_api.websocket_command({vol.Required("type"): f"{DOMAIN}/get_admins"})
@@ -82,9 +82,6 @@ async def websocket_login(
 
     stored_pin = user_pins.get(msg["user"])
     if stored_pin and verify_pin(str(msg["pin"]), stored_pin):
-        if stored_pin.count("$") == 1:
-            user_pins[msg["user"]] = hash_pin(str(msg["pin"]))
-            await hass.data[DOMAIN]["pins_store"].async_save(user_pins)
         hass.data[DOMAIN].setdefault("logins", {})[
             connection.user.id
         ] = msg["user"]


### PR DESCRIPTION
## Summary
- drop support for legacy two-part PIN hashes
- simplify login logic by removing automatic rehashing

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b753ea80ec832e9152d6b6d25684ee