### PR TITLE
Clean config entry after migrating user pin to storage

### DIFF
--- a/custom_components/tally_list/__init__.py
+++ b/custom_components/tally_list/__init__.py
@@ -716,6 +716,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await hass.data[DOMAIN]["pins_store"].async_save(
             hass.data[DOMAIN][CONF_USER_PINS]
         )
+        entry_data = dict(entry.data)
+        entry_data.pop(CONF_USER_PIN, None)
+        hass.config_entries.async_update_entry(entry, data=entry_data)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 


### PR DESCRIPTION
## Summary
- Remove `user_pin` from config entry after migrating to pin store

## Testing
- `python -m py_compile custom_components/tally_list/__init__.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b756adb848832ebdbdc86b7782e50b