### PR TITLE
Remove backward compatible price list user constant

### DIFF
--- a/custom_components/tally_list/const.py
+++ b/custom_components/tally_list/const.py
@@ -31,8 +31,6 @@ SERVICE_SET_PIN = "set_pin"
 # Dedicated user name that exposes drink prices
 PRICE_LIST_USER_DE = "Preisliste"
 PRICE_LIST_USER_EN = "Price list"
-# Default name for backward compatibility
-PRICE_LIST_USER = PRICE_LIST_USER_DE
 PRICE_LIST_USERS = {PRICE_LIST_USER_DE, PRICE_LIST_USER_EN}
 
 CASH_USER_DE = "Freigetränke"


### PR DESCRIPTION
## Summary
- drop `PRICE_LIST_USER` constant that kept default name "Preisliste"

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b75674dd08832e82ad9ca7f864c77c