### PR TITLE
Handle storage errors when setting PIN

### DIFF
--- a/custom_components/tally_list/translations/de.json
+++ b/custom_components/tally_list/translations/de.json
@@ -321,7 +321,8 @@
     "drink_unknown": "Unbekanntes Getränk",
     "user_unknown": "Unbekannte Person",
     "cannot_remove_count": "Anzahl kann nicht entfernt werden",
-    "invalid_pin": "PIN muss genau vier Ziffern haben"
+    "invalid_pin": "PIN muss genau vier Ziffern haben",
+    "pin_save_failed": "Speichern der PIN ist fehlgeschlagen"
   },
   "services": {
     "add_drink": {

--- a/custom_components/tally_list/translations/en.json
+++ b/custom_components/tally_list/translations/en.json
@@ -321,7 +321,8 @@
     "drink_unknown": "Unknown drink",
     "user_unknown": "Unknown person",
     "cannot_remove_count": "Cannot remove count",
-    "invalid_pin": "PIN must consist of exactly four digits"
+    "invalid_pin": "PIN must consist of exactly four digits",
+    "pin_save_failed": "Failed to save PIN"
   },
   "services": {
     "add_drink": {


### PR DESCRIPTION
## Summary
- guard PIN storage with try/except and revert on failure
- log storage errors and expose translated error messages

## Testing
- `python -m py_compile custom_components/tally_list/__init__.py`
- `python -m json.tool custom_components/tally_list/translations/en.json`
- `python -m json.tool custom_components/tally_list/translations/de.json`


------
https://chatgpt.com/codex/tasks/task_e_68b7592791e0832eb557f283135adf80