### PR TITLE
Refactor person lookup into helper and add tests

### DIFF
--- a/custom_components/tally_list/__init__.py
+++ b/custom_components/tally_list/__init__.py
@@ -19,6 +19,7 @@ from homeassistant.helpers.storage import Store
 from .websocket import async_register as async_register_ws
 from .sensor import FreeDrinkFeedSensor
 from .security import hash_pin, verify_pin
+from .utils import get_person_name
 
 from .const import (
     DOMAIN,
@@ -89,11 +90,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         public_devices = hass.data.get(DOMAIN, {}).get(CONF_PUBLIC_DEVICES, [])
         user_pins = hass.data.get(DOMAIN, {}).get(CONF_USER_PINS, {})
         logins = hass.data.get(DOMAIN, {}).get("logins", {})
-        person_name = None
-        for state in hass.states.async_all("person"):
-            if state.attributes.get("user_id") == hass_user.id:
-                person_name = state.name
-                break
+        person_name = get_person_name(hass, hass_user.id)
         if person_name in override_users:
             return
         if person_name in public_devices and target_user:
@@ -169,11 +166,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         hass_user = await hass.auth.async_get_user(user_id)
         if hass_user is None:
             raise Unauthorized
-        person_name = None
-        for state in hass.states.async_all("person"):
-            if state.attributes.get("user_id") == hass_user.id:
-                person_name = state.name
-                break
+        person_name = get_person_name(hass, hass_user.id)
         if person_name is None:
             raise HomeAssistantError(
                 translation_domain=DOMAIN, translation_key="user_unknown"

--- a/custom_components/tally_list/button.py
+++ b/custom_components/tally_list/button.py
@@ -8,6 +8,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import Unauthorized
 from homeassistant.util import slugify
 
+from .utils import get_person_name
+
 from .const import (
     DOMAIN,
     SERVICE_RESET_COUNTERS,
@@ -48,11 +50,7 @@ class ResetButton(ButtonEntity):
                     CONF_OVERRIDE_USERS,
                     [],
                 )
-                person_name = None
-                for state in self._hass.states.async_all("person"):
-                    if state.attributes.get("user_id") == hass_user.id:
-                        person_name = state.name
-                        break
+                person_name = get_person_name(self._hass, hass_user.id)
                 if person_name not in override_users:
                     raise Unauthorized
 

--- a/custom_components/tally_list/utils.py
+++ b/custom_components/tally_list/utils.py
@@ -1,0 +1,30 @@
+"""Utility helpers for Tally List."""
+
+from __future__ import annotations
+
+from typing import Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+else:  # pragma: no cover - used only for type hints
+    HomeAssistant = Any
+
+
+def get_person_name(hass: HomeAssistant, user_id: str | None) -> str | None:
+    """Return the person name for a Home Assistant user ID.
+
+    Parameters:
+        hass: HomeAssistant instance used to access state data.
+        user_id: The Home Assistant user ID to look up.
+
+    Returns:
+        The name of the person entity linked to the user ID, or ``None`` if no
+        matching person is found or ``user_id`` is ``None``.
+    """
+    if user_id is None:
+        return None
+
+    for state in hass.states.async_all("person"):
+        if state.attributes.get("user_id") == user_id:
+            return state.name
+    return None

--- a/custom_components/tally_list/websocket.py
+++ b/custom_components/tally_list/websocket.py
@@ -14,6 +14,7 @@ from .const import (
     CONF_USER_PINS,
 )
 from .security import verify_pin
+from .utils import get_person_name
 
 
 @websocket_api.websocket_command({vol.Required("type"): f"{DOMAIN}/get_admins"})
@@ -42,11 +43,7 @@ async def websocket_is_public_device(
     if connection.user is None:
         raise Unauthorized
 
-    person_name: str | None = None
-    for state in hass.states.async_all("person"):
-        if state.attributes.get("user_id") == connection.user.id:
-            person_name = state.name
-            break
+    person_name = get_person_name(hass, connection.user.id)
 
     public_devices = hass.data.get(DOMAIN, {}).get(CONF_PUBLIC_DEVICES, [])
     connection.send_result(msg["id"], {"is_public": person_name in public_devices})
@@ -69,11 +66,7 @@ async def websocket_login(
     if connection.user is None:
         raise Unauthorized
 
-    person_name: str | None = None
-    for state in hass.states.async_all("person"):
-        if state.attributes.get("user_id") == connection.user.id:
-            person_name = state.name
-            break
+    person_name = get_person_name(hass, connection.user.id)
 
     public_devices = hass.data.get(DOMAIN, {}).get(CONF_PUBLIC_DEVICES, [])
     user_pins = hass.data.get(DOMAIN, {}).get(CONF_USER_PINS, {})

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,42 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "custom_components" / "tally_list"))
+
+from utils import get_person_name
+
+
+class DummyState:
+    def __init__(self, name, user_id):
+        self.name = name
+        self.attributes = {"user_id": user_id}
+
+
+class DummyStates:
+    def __init__(self, states):
+        self._states = states
+
+    def async_all(self, domain):
+        assert domain == "person"
+        return self._states
+
+
+class DummyHass:
+    def __init__(self, states):
+        self.states = DummyStates(states)
+
+
+def test_get_person_name_found():
+    hass = DummyHass([DummyState("Alice", "user-1"), DummyState("Bob", "user-2")])
+    assert get_person_name(hass, "user-2") == "Bob"
+
+
+def test_get_person_name_not_found():
+    hass = DummyHass([])
+    assert get_person_name(hass, "user-1") is None
+
+
+def test_get_person_name_no_user_id():
+    hass = DummyHass([DummyState("Alice", "user-1")])
+    assert get_person_name(hass, None) is None
+


### PR DESCRIPTION
## Summary
- add `get_person_name` helper for resolving HA user IDs to person names
- refactor services, button, and websocket handlers to use helper
- test `get_person_name` for typical and edge cases

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b75e07ad9c832eb73278269abac67a