### PR TITLE
Add user slug helper

### DIFF
--- a/custom_components/tally_list/button.py
+++ b/custom_components/tally_list/button.py
@@ -6,9 +6,8 @@ from homeassistant.components.button import ButtonEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import Unauthorized
-from homeassistant.util import slugify
 
-from .utils import get_person_name
+from .utils import get_person_name, get_user_slug
 
 from .const import (
     DOMAIN,
@@ -16,8 +15,6 @@ from .const import (
     CONF_USER,
     CONF_OVERRIDE_USERS,
     PRICE_LIST_USERS,
-    CONF_CASH_USER_NAME,
-    CASH_USER_SLUG,
 )
 
 
@@ -35,10 +32,7 @@ class ResetButton(ButtonEntity):
         user = entry.data[CONF_USER]
         self._attr_name = f"{user} Reset"
         self._attr_unique_id = f"{entry.entry_id}_reset_tally"
-        user_slug = slugify(user)
-        cash_name = hass.data.get(DOMAIN, {}).get(CONF_CASH_USER_NAME, "")
-        if user.strip().lower() == cash_name.strip().lower():
-            user_slug = CASH_USER_SLUG
+        user_slug = get_user_slug(hass, user)
         self.entity_id = f"button.{user_slug}_reset_tally"
 
     async def async_press(self) -> None:

--- a/custom_components/tally_list/sensor.py
+++ b/custom_components/tally_list/sensor.py
@@ -16,13 +16,14 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.util import slugify
 
+from .utils import get_user_slug
+
 from .const import (
     DOMAIN,
     CONF_USER,
     PRICE_LIST_USERS,
     CONF_CURRENCY,
     CONF_CASH_USER_NAME,
-    CASH_USER_SLUG,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -102,10 +103,7 @@ class TallyListSensor(RestoreEntity, SensorEntity):
             f"{_local_suffix(hass, 'Count', 'Anzahl')}"
         )
         self._attr_unique_id = f"{entry.entry_id}_{drink}_count"
-        user_slug = slugify(entry.data[CONF_USER])
-        cash_name = hass.data.get(DOMAIN, {}).get(CONF_CASH_USER_NAME, "")
-        if entry.data[CONF_USER].strip().lower() == cash_name.strip().lower():
-            user_slug = CASH_USER_SLUG
+        user_slug = get_user_slug(hass, entry.data[CONF_USER])
         self.entity_id = f"sensor.{user_slug}_{slugify(drink)}_count"
         self._attr_native_value = 0
         self._attr_native_unit_of_measurement = None
@@ -220,10 +218,7 @@ class TotalAmountSensor(RestoreEntity, SensorEntity):
             f"{_local_suffix(hass, 'Amount due', 'Offener Betrag')}"
         )
         self._attr_unique_id = f"{entry.entry_id}_amount_due"
-        user_slug = slugify(entry.data[CONF_USER])
-        cash_name = hass.data.get(DOMAIN, {}).get(CONF_CASH_USER_NAME, "")
-        if entry.data[CONF_USER].strip().lower() == cash_name.strip().lower():
-            user_slug = CASH_USER_SLUG
+        user_slug = get_user_slug(hass, entry.data[CONF_USER])
         self.entity_id = f"sensor.{user_slug}_amount_due"
         self._attr_native_unit_of_measurement = hass.data.get(DOMAIN, {}).get(
             CONF_CURRENCY, "€"

--- a/custom_components/tally_list/utils.py
+++ b/custom_components/tally_list/utils.py
@@ -4,10 +4,30 @@ from __future__ import annotations
 
 from typing import Any, TYPE_CHECKING
 
+try:
+    from homeassistant.util import slugify
+except Exception:  # pragma: no cover - Home Assistant not available
+    import re
+    import unicodedata
+
+    def slugify(value: str) -> str:
+        """Simplified fallback slugify implementation."""
+        normalized = (
+            unicodedata.normalize("NFKD", value)
+            .encode("ascii", "ignore")
+            .decode("ascii")
+        )
+        return re.sub(r"[^a-z0-9_]+", "_", normalized.lower()).strip("_")
+
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
 else:  # pragma: no cover - used only for type hints
     HomeAssistant = Any
+
+try:
+    from .const import DOMAIN, CONF_CASH_USER_NAME, CASH_USER_SLUG
+except Exception:  # pragma: no cover - direct import for tests
+    from const import DOMAIN, CONF_CASH_USER_NAME, CASH_USER_SLUG
 
 
 def get_person_name(hass: HomeAssistant, user_id: str | None) -> str | None:
@@ -28,3 +48,14 @@ def get_person_name(hass: HomeAssistant, user_id: str | None) -> str | None:
         if state.attributes.get("user_id") == user_id:
             return state.name
     return None
+
+
+def get_user_slug(hass: HomeAssistant, username: str) -> str:
+    """Return the slug for a user name.
+
+    Applies Home Assistant's ``slugify`` and handles the special cash user.
+    """
+    cash_name = hass.data.get(DOMAIN, {}).get(CONF_CASH_USER_NAME, "")
+    if username.strip().lower() == cash_name.strip().lower():
+        return CASH_USER_SLUG
+    return slugify(username)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,8 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "custom_components" / "tally_list"))
 
-from utils import get_person_name
+from const import DOMAIN, CONF_CASH_USER_NAME, CASH_USER_SLUG
+from utils import get_person_name, get_user_slug
 
 
 class DummyState:
@@ -22,8 +23,9 @@ class DummyStates:
 
 
 class DummyHass:
-    def __init__(self, states):
+    def __init__(self, states, data=None):
         self.states = DummyStates(states)
+        self.data = data or {}
 
 
 def test_get_person_name_found():
@@ -39,4 +41,14 @@ def test_get_person_name_not_found():
 def test_get_person_name_no_user_id():
     hass = DummyHass([DummyState("Alice", "user-1")])
     assert get_person_name(hass, None) is None
+
+
+def test_get_user_slug_regular():
+    hass = DummyHass([], {DOMAIN: {CONF_CASH_USER_NAME: "Cash"}})
+    assert get_user_slug(hass, "John Doe") == "john_doe"
+
+
+def test_get_user_slug_cash_user():
+    hass = DummyHass([], {DOMAIN: {CONF_CASH_USER_NAME: "Cash"}})
+    assert get_user_slug(hass, "cash") == CASH_USER_SLUG
 


### PR DESCRIPTION
## Summary
- centralize user slug logic with new `get_user_slug`
- refactor sensors and button to use helper
- test slug handling for regular and cash users

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7607f5300832ea542db3cfe653f58