### PR TITLE
Refactor config flow with shared helpers

### DIFF
--- a/custom_components/tally_list/base_flow.py
+++ b/custom_components/tally_list/base_flow.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+import voluptuous as vol
+from homeassistant.helpers import entity_registry as er
+
+from .const import (
+    CONF_CURRENCY,
+    CONF_DRINK,
+    CONF_DRINKS,
+    CONF_ENABLE_FREE_DRINKS,
+    CONF_FREE_AMOUNT,
+    CONF_OVERRIDE_USERS,
+    CONF_PRICE,
+    CONF_PUBLIC_DEVICES,
+    CONF_USER,
+    CONF_EXCLUDED_USERS,
+)
+from .flow_helpers import Step, build_choice_schema, get_available_persons
+
+
+class TallyListFlowHandler:
+    """Common logic for Tally List config and options flows."""
+
+    MENU_OPTIONS: list[Step] = [Step.USER, Step.DRINKS, Step.FINISH]
+    DRINK_MENU: list[Step] = [
+        Step.ADD_DRINK,
+        Step.REMOVE_DRINK,
+        Step.EDIT_PRICE,
+        Step.CURRENCY,
+        Step.BACK,
+    ]
+
+    def __init__(self) -> None:
+        self._drinks: dict[str, float] = {}
+        self._free_amount: float = 0.0
+        self._excluded_users: list[str] = []
+        self._override_users: list[str] = []
+        self._public_devices: list[str] = []
+        self._currency: str = "€"
+        self._enable_free_drinks: bool = False
+
+    async def async_step_menu(self, user_input=None):
+        return self.async_show_menu(
+            step_id=Step.MENU,
+            menu_options=[step.value for step in self.MENU_OPTIONS],
+        )
+
+    async def async_step_drinks(self, user_input=None):
+        return self.async_show_menu(
+            step_id=Step.DRINKS,
+            menu_options=[step.value for step in self.DRINK_MENU],
+        )
+
+    async def async_step_back(self, user_input=None):
+        return await self.async_step_menu()
+
+    async def async_step_add(self, user_input=None):
+        return await self.async_step_add_drink(user_input)
+
+    async def async_step_remove(self, user_input=None):
+        return await self.async_step_remove_drink(user_input)
+
+    async def async_step_edit(self, user_input=None):
+        return await self.async_step_edit_price(user_input)
+
+    async def async_step_free_amount(self, user_input=None):
+        return await self.async_step_set_free_amount(user_input)
+
+    async def async_step_currency(self, user_input=None):
+        if user_input is not None:
+            self._currency = user_input[CONF_CURRENCY]
+            return await self.async_step_menu()
+        schema = vol.Schema({vol.Required(CONF_CURRENCY, default=self._currency): str})
+        return self.async_show_form(step_id=Step.CURRENCY, data_schema=schema)
+
+    async def async_step_add_drink(self, user_input=None):
+        if user_input is not None:
+            drink = user_input[CONF_DRINK]
+            price = float(user_input[CONF_PRICE])
+            self._drinks[drink] = price
+            if user_input.get("add_more"):
+                return await self.async_step_add_drink()
+            return await self.async_step_menu()
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_DRINK): str,
+                vol.Required(CONF_PRICE): vol.Coerce(float),
+                vol.Optional("add_more", default=False): bool,
+            }
+        )
+        return self.async_show_form(step_id=Step.ADD_DRINK, data_schema=schema)
+
+    async def async_step_remove_drink(self, user_input=None):
+        if user_input is not None:
+            drink = user_input[CONF_DRINK]
+            self._drinks.pop(drink, None)
+            if user_input.get("remove_more") and self._drinks:
+                return await self.async_step_remove_drink()
+            return await self.async_step_menu()
+        if not self._drinks:
+            return await self.async_step_menu()
+        schema = build_choice_schema(CONF_DRINK, self._drinks.keys(), "remove_more")
+        return self.async_show_form(step_id=Step.REMOVE_DRINK, data_schema=schema)
+
+    async def async_step_edit_price(self, user_input=None):
+        if user_input is not None:
+            drink = user_input[CONF_DRINK]
+            price = float(user_input[CONF_PRICE])
+            self._drinks[drink] = price
+            if user_input.get("edit_more") and self._drinks:
+                return await self.async_step_edit_price()
+            return await self.async_step_menu()
+        if not self._drinks:
+            return await self.async_step_menu()
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_DRINK): vol.In(list(self._drinks.keys())),
+                vol.Required(CONF_PRICE): vol.Coerce(float),
+                vol.Optional("edit_more", default=False): bool,
+            }
+        )
+        return self.async_show_form(step_id=Step.EDIT_PRICE, data_schema=schema)
+
+    async def async_step_set_free_amount(self, user_input=None):
+        if user_input is not None:
+            self._free_amount = float(user_input[CONF_FREE_AMOUNT])
+            return await self.async_step_menu()
+        schema = vol.Schema(
+            {vol.Required(CONF_FREE_AMOUNT, default=self._free_amount): vol.Coerce(float)}
+        )
+        return self.async_show_form(step_id=Step.FREE_AMOUNT, data_schema=schema)
+    async def async_step_add_excluded_user(self, user_input=None):
+        registry = er.async_get(self.hass)
+        persons = get_available_persons(registry, self.hass.states, self._excluded_users)
+        if not persons:
+            return await self.async_step_menu()
+        if user_input is not None:
+            user = user_input[CONF_USER]
+            self._excluded_users.append(user)
+            if user_input.get("add_more") and len(persons) > 1:
+                return await self.async_step_add_excluded_user()
+            return await self.async_step_menu()
+        schema = build_choice_schema(CONF_USER, persons, "add_more")
+        return self.async_show_form(step_id=Step.ADD_EXCLUDED_USER, data_schema=schema)
+
+    async def async_step_remove_excluded_user(self, user_input=None):
+        if user_input is not None:
+            user = user_input[CONF_USER]
+            if user in self._excluded_users:
+                self._excluded_users.remove(user)
+            if user_input.get("remove_more") and self._excluded_users:
+                return await self.async_step_remove_excluded_user()
+            return await self.async_step_menu()
+        if not self._excluded_users:
+            return await self.async_step_menu()
+        schema = build_choice_schema(CONF_USER, self._excluded_users, "remove_more")
+        return self.async_show_form(step_id=Step.REMOVE_EXCLUDED_USER, data_schema=schema)
+
+    async def async_step_add_override_user(self, user_input=None):
+        registry = er.async_get(self.hass)
+        persons = get_available_persons(registry, self.hass.states, self._override_users)
+        if not persons:
+            return await self.async_step_menu()
+        if user_input is not None:
+            user = user_input[CONF_USER]
+            self._override_users.append(user)
+            if user_input.get("add_more") and len(persons) > 1:
+                return await self.async_step_add_override_user()
+            return await self.async_step_menu()
+        schema = build_choice_schema(CONF_USER, persons, "add_more")
+        return self.async_show_form(step_id=Step.ADD_OVERRIDE_USER, data_schema=schema)
+
+    async def async_step_remove_override_user(self, user_input=None):
+        if user_input is not None:
+            user = user_input[CONF_USER]
+            if user in self._override_users:
+                self._override_users.remove(user)
+            if user_input.get("remove_more") and self._override_users:
+                return await self.async_step_remove_override_user()
+            return await self.async_step_menu()
+        if not self._override_users:
+            return await self.async_step_menu()
+        schema = build_choice_schema(CONF_USER, self._override_users, "remove_more")
+        return self.async_show_form(step_id=Step.REMOVE_OVERRIDE_USER, data_schema=schema)
+
+    async def async_step_add_public_user(self, user_input=None):
+        registry = er.async_get(self.hass)
+        persons = get_available_persons(registry, self.hass.states, self._public_devices)
+        if not persons:
+            return await self.async_step_menu()
+        if user_input is not None:
+            user = user_input[CONF_USER]
+            self._public_devices.append(user)
+            if user_input.get("add_more") and len(persons) > 1:
+                return await self.async_step_add_public_user()
+            return await self.async_step_menu()
+        schema = build_choice_schema(CONF_USER, persons, "add_more")
+        return self.async_show_form(step_id=Step.ADD_PUBLIC_USER, data_schema=schema)
+
+    async def async_step_remove_public_user(self, user_input=None):
+        if user_input is not None:
+            user = user_input[CONF_USER]
+            if user in self._public_devices:
+                self._public_devices.remove(user)
+            if user_input.get("remove_more") and self._public_devices:
+                return await self.async_step_remove_public_user()
+            return await self.async_step_menu()
+        if not self._public_devices:
+            return await self.async_step_menu()
+        schema = build_choice_schema(CONF_USER, self._public_devices, "remove_more")
+        return self.async_show_form(step_id=Step.REMOVE_PUBLIC_USER, data_schema=schema)
+
+    async def async_step_authorize(self, user_input=None):
+        return await self.async_step_add_override_user(user_input)
+
+    async def async_step_unauthorize(self, user_input=None):
+        return await self.async_step_remove_override_user(user_input)
+
+    async def async_step_authorize_public(self, user_input=None):
+        return await self.async_step_add_public_user(user_input)
+
+    async def async_step_unauthorize_public(self, user_input=None):
+        return await self.async_step_remove_public_user(user_input)
+
+    async def async_step_free_drinks(self, user_input=None):
+        if user_input is not None:
+            enable = user_input[CONF_ENABLE_FREE_DRINKS]
+            if self._enable_free_drinks and not enable:
+                return await self.async_step_free_drinks_confirm()
+            self._enable_free_drinks = enable
+            return await self.async_step_menu()
+        schema = vol.Schema(
+            {vol.Required(CONF_ENABLE_FREE_DRINKS, default=self._enable_free_drinks): bool}
+        )
+        return self.async_show_form(step_id=Step.FREE_DRINKS, data_schema=schema)
+
+    async def async_step_free_drinks_confirm(self, user_input=None):
+        errors = {}
+        if user_input is not None:
+            confirmation = user_input.get("confirm", "").strip().upper()
+            if confirmation in {"JA ICH WILL", "YES I WANT"}:
+                self._enable_free_drinks = False
+                return await self.async_step_menu()
+            errors["base"] = "confirmation_required"
+        schema = vol.Schema({vol.Required("confirm"): str})
+        return self.async_show_form(
+            step_id=Step.FREE_DRINKS_CONFIRM, data_schema=schema, errors=errors
+        )

--- a/custom_components/tally_list/flow_helpers.py
+++ b/custom_components/tally_list/flow_helpers.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Iterable, Mapping
+
+import voluptuous as vol
+
+from .const import PRICE_LIST_USERS
+
+
+class Step(str, Enum):
+    """Flow step names used by config and options flows."""
+
+    USER = "user"
+    MENU = "menu"
+    DRINKS = "drinks"
+    ADD_DRINK = "add_drink"
+    REMOVE_DRINK = "remove_drink"
+    EDIT_PRICE = "edit_price"
+    CURRENCY = "currency"
+    FREE_AMOUNT = "free_amount"
+    FREE_DRINKS = "free_drinks"
+    FREE_DRINKS_CONFIRM = "free_drinks_confirm"
+    EXCLUDE = "exclude"
+    INCLUDE = "include"
+    AUTHORIZE = "authorize"
+    UNAUTHORIZE = "unauthorize"
+    AUTHORIZE_PUBLIC = "authorize_public"
+    UNAUTHORIZE_PUBLIC = "unauthorize_public"
+    ADD_EXCLUDED_USER = "add_excluded_user"
+    REMOVE_EXCLUDED_USER = "remove_excluded_user"
+    ADD_OVERRIDE_USER = "add_override_user"
+    REMOVE_OVERRIDE_USER = "remove_override_user"
+    ADD_PUBLIC_USER = "add_public_user"
+    REMOVE_PUBLIC_USER = "remove_public_user"
+    FINISH = "finish"
+    BACK = "back"
+    CLEANUP = "cleanup"
+    CLEANUP_RESULT = "cleanup_result"
+    CLEANUP_RESULT_EMPTY = "cleanup_result_empty"
+    DELETE = "delete"
+
+
+def parse_drinks(value: str) -> dict[str, float]:
+    """Parse a comma-separated drink string into a dict."""
+    drinks: dict[str, float] = {}
+    if not value:
+        return drinks
+    for part in value.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        if "=" not in part:
+            raise ValueError
+        name, price = part.split("=", 1)
+        drinks[name.strip()] = float(price)
+    return drinks
+
+
+def build_choice_schema(key: str, options: Iterable[str], more_key: str | None = None) -> vol.Schema:
+    """Return a schema for selecting from a list of options."""
+    schema: dict = {vol.Required(key): vol.In(list(options))}
+    if more_key is not None:
+        schema[vol.Optional(more_key, default=False)] = bool
+    return vol.Schema(schema)
+
+
+def get_available_persons(registry: Any, states: Mapping[str, Any], exclude: Iterable[str]) -> list[str]:
+    """Return available person names from the registry excluding provided names."""
+    persons = [
+        entry.original_name or entry.name or entry.entity_id
+        for entry in registry.entities.values()
+        if entry.domain == "person"
+        and (
+            (state := states.get(entry.entity_id))
+            and state.attributes.get("user_id")
+        )
+    ]
+    return [p for p in persons if p not in exclude and p not in PRICE_LIST_USERS]

--- a/custom_components/tally_list/options_flow.py
+++ b/custom_components/tally_list/options_flow.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import logging
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.helpers import entity_registry as er
+
+from .const import (
+    CONF_CASH_USER_NAME,
+    CONF_CURRENCY,
+    CONF_DRINKS,
+    CONF_ENABLE_FREE_DRINKS,
+    CONF_EXCLUDED_USERS,
+    CONF_FREE_AMOUNT,
+    CONF_OVERRIDE_USERS,
+    CONF_PUBLIC_DEVICES,
+    CONF_USER,
+    DOMAIN,
+    get_cash_user_name,
+)
+from .base_flow import TallyListFlowHandler
+from .flow_helpers import Step
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class TallyListOptionsFlowHandler(config_entries.OptionsFlow, TallyListFlowHandler):
+    """Handle options for existing entries."""
+
+    MENU_OPTIONS = [Step.USER, Step.DRINKS, Step.CLEANUP, Step.DELETE, Step.FINISH]
+    DRINK_MENU = [
+        Step.ADD_DRINK,
+        Step.REMOVE_DRINK,
+        Step.EDIT_PRICE,
+        Step.CURRENCY,
+        Step.FREE_DRINKS,
+        Step.BACK,
+    ]
+
+    def __init__(self, config_entry):
+        super().__init__()
+        self.config_entry = config_entry
+        self._cash_user_name: str = get_cash_user_name(None)
+
+    async def async_step_init(self, user_input=None):
+        self._drinks = self.hass.data.get(DOMAIN, {}).get("drinks", {}).copy()
+        self._free_amount = self.hass.data.get(DOMAIN, {}).get("free_amount", 0.0)
+        self._excluded_users = (
+            self.hass.data.get(DOMAIN, {}).get(CONF_EXCLUDED_USERS, [])
+        ).copy()
+        self._override_users = (
+            self.hass.data.get(DOMAIN, {}).get(CONF_OVERRIDE_USERS, [])
+        ).copy()
+        self._public_devices = (
+            self.hass.data.get(DOMAIN, {}).get(CONF_PUBLIC_DEVICES, [])
+        ).copy()
+        self._currency = self.hass.data.get(DOMAIN, {}).get(CONF_CURRENCY, "€")
+        self._enable_free_drinks = self.hass.data.get(DOMAIN, {}).get(
+            CONF_ENABLE_FREE_DRINKS, False
+        )
+        self._cash_user_name = get_cash_user_name(getattr(self.hass.config, "language", None))
+        return await self.async_step_menu()
+
+    async def async_step_user(self, user_input=None):
+        return self.async_show_menu(
+            step_id=Step.USER,
+            menu_options=[
+                Step.FREE_AMOUNT.value,
+                Step.EXCLUDE.value,
+                Step.INCLUDE.value,
+                Step.AUTHORIZE.value,
+                Step.UNAUTHORIZE.value,
+                Step.AUTHORIZE_PUBLIC.value,
+                Step.UNAUTHORIZE_PUBLIC.value,
+                Step.BACK.value,
+            ],
+        )
+
+    async def async_step_free_drinks(self, user_input=None):
+        if user_input is not None:
+            enable = user_input[CONF_ENABLE_FREE_DRINKS]
+            if self._enable_free_drinks and not enable:
+                return await self.async_step_free_drinks_confirm()
+            self._enable_free_drinks = enable
+            return await self.async_step_drinks()
+        schema = vol.Schema(
+            {vol.Required(CONF_ENABLE_FREE_DRINKS, default=self._enable_free_drinks): bool}
+        )
+        return self.async_show_form(step_id=Step.FREE_DRINKS, data_schema=schema)
+
+    async def async_step_free_drinks_confirm(self, user_input=None):
+        errors = {}
+        if user_input is not None:
+            confirmation = user_input.get("confirm", "").strip().upper()
+            if confirmation in {"JA ICH WILL", "YES I WANT"}:
+                self._enable_free_drinks = False
+                return await self.async_step_drinks()
+            errors["base"] = "confirmation_required"
+        schema = vol.Schema({vol.Required("confirm"): str})
+        return self.async_show_form(
+            step_id=Step.FREE_DRINKS_CONFIRM, data_schema=schema, errors=errors
+        )
+
+    async def async_step_cleanup(self, user_input=None):
+        errors = {}
+        if user_input is not None:
+            confirmation = user_input.get("confirm", "").strip().upper()
+            if confirmation in {"JA ICH WILL", "YES I WANT"}:
+                removed = await self._cleanup_unused_entities()
+                if removed:
+                    return self.async_show_form(
+                        step_id=Step.CLEANUP_RESULT,
+                        description_placeholders={"sensors": "\n- ".join(sorted(removed))},
+                    )
+                return self.async_show_form(step_id=Step.CLEANUP_RESULT_EMPTY)
+            errors["base"] = "invalid_confirmation"
+        schema = vol.Schema({vol.Required("confirm"): str})
+        return self.async_show_form(step_id=Step.CLEANUP, data_schema=schema, errors=errors)
+
+    async def async_step_cleanup_result(self, user_input=None):
+        return await self.async_step_menu()
+
+    async def async_step_cleanup_result_empty(self, user_input=None):
+        return await self.async_step_menu()
+
+    async def async_step_delete(self, user_input=None):
+        errors = {}
+        if user_input is not None:
+            confirmation = user_input.get("confirm", "").strip().upper()
+            if confirmation in {"JA ICH WILL", "YES I WANT"}:
+                await self._delete_all_entries()
+                return self.async_abort(reason="delete_all")
+            errors["base"] = "invalid_confirmation"
+        schema = vol.Schema({vol.Required("confirm"): str})
+        return self.async_show_form(step_id=Step.DELETE, data_schema=schema, errors=errors)
+
+    async def async_step_finish(self, user_input=None):
+        return await self._update_drinks()
+
+    async def _cleanup_unused_entities(self) -> list[str]:
+        registry = er.async_get(self.hass)
+        to_remove: list[str] = []
+        for entity_entry in list(registry.entities.values()):
+            if entity_entry.domain == "sensor" and entity_entry.platform == DOMAIN:
+                if entity_entry.entity_id not in self.hass.data.get(DOMAIN, {})\
+                    .get("sensors", []):
+                    to_remove.append(entity_entry.entity_id)
+                    await registry.async_remove(entity_entry.entity_id)
+        return to_remove
+
+    async def _delete_all_entries(self) -> None:
+        entries = list(self.hass.config_entries.async_entries(DOMAIN))
+        for entry in entries:
+            await self.hass.config_entries.async_remove(entry.entry_id)
+
+        registry = er.async_get(self.hass)
+        for entity_entry in list(registry.entities.values()):
+            if entity_entry.domain == "sensor" and entity_entry.platform == DOMAIN:
+                try:
+                    await registry.async_remove(entity_entry.entity_id)
+                except Exception as exc:  # pragma: no cover
+                    _LOGGER.error("Failed to remove %s: %s", entity_entry.entity_id, exc)
+
+        self.hass.data.pop(DOMAIN, None)
+
+    async def _update_drinks(self):
+        self.hass.data.setdefault(DOMAIN, {})["drinks"] = self._drinks
+        self.hass.data[DOMAIN]["free_amount"] = self._free_amount
+        self.hass.data[DOMAIN][CONF_EXCLUDED_USERS] = self._excluded_users
+        self.hass.data[DOMAIN][CONF_OVERRIDE_USERS] = self._override_users
+        self.hass.data[DOMAIN][CONF_PUBLIC_DEVICES] = self._public_devices
+        self.hass.data[DOMAIN][CONF_CURRENCY] = self._currency
+        self.hass.data[DOMAIN][CONF_CASH_USER_NAME] = self._cash_user_name
+        entries = self.hass.config_entries.async_entries(DOMAIN)
+        for entry in entries:
+            data = {
+                CONF_USER: entry.data[CONF_USER],
+                CONF_DRINKS: self._drinks,
+                CONF_FREE_AMOUNT: self._free_amount,
+                CONF_EXCLUDED_USERS: self._excluded_users,
+                CONF_OVERRIDE_USERS: self._override_users,
+                CONF_PUBLIC_DEVICES: self._public_devices,
+                CONF_CURRENCY: self._currency,
+                CONF_ENABLE_FREE_DRINKS: self._enable_free_drinks,
+                CONF_CASH_USER_NAME: self._cash_user_name,
+            }
+            self.hass.config_entries.async_update_entry(entry, data=data)
+            await self.hass.config_entries.async_reload(entry.entry_id)
+        for entry in entries:
+            value = self.hass.data.get(DOMAIN, {}).get(entry.entry_id)
+            if isinstance(value, dict):
+                for sensor in value.get("sensors", []):
+                    await sensor.async_update_state()
+        return self.async_create_entry(
+            title="",
+            data={
+                CONF_DRINKS: self._drinks,
+                CONF_FREE_AMOUNT: self._free_amount,
+                CONF_EXCLUDED_USERS: self._excluded_users,
+                CONF_OVERRIDE_USERS: self._override_users,
+                CONF_PUBLIC_DEVICES: self._public_devices,
+                CONF_CURRENCY: self._currency,
+                CONF_ENABLE_FREE_DRINKS: self._enable_free_drinks,
+                CONF_CASH_USER_NAME: self._cash_user_name,
+            },
+        )

--- a/tests/test_flow_helpers.py
+++ b/tests/test_flow_helpers.py
@@ -1,0 +1,50 @@
+import importlib
+import pathlib
+import sys
+from types import SimpleNamespace, ModuleType
+
+import pytest
+import voluptuous as vol
+
+# Create a dummy package structure so flow_helpers can resolve relative imports
+pkg = ModuleType("custom_components")
+pkg.__path__ = []
+sys.modules.setdefault("custom_components", pkg)
+subpkg = ModuleType("custom_components.tally_list")
+subpkg.__path__ = [str(pathlib.Path(__file__).resolve().parent.parent / "custom_components" / "tally_list")]
+sys.modules["custom_components.tally_list"] = subpkg
+
+flow_helpers = importlib.import_module("custom_components.tally_list.flow_helpers")
+from custom_components.tally_list.const import PRICE_LIST_USER_EN
+
+build_choice_schema = flow_helpers.build_choice_schema
+get_available_persons = flow_helpers.get_available_persons
+parse_drinks = flow_helpers.parse_drinks
+
+
+def test_parse_drinks():
+    result = parse_drinks("cola=1.5, beer=2")
+    assert result == {"cola": 1.5, "beer": 2.0}
+    with pytest.raises(ValueError):
+        parse_drinks("invalid")
+
+
+def test_build_choice_schema():
+    schema = build_choice_schema("drink", ["a", "b"], "more")
+    data = schema({"drink": "a", "more": True})
+    assert data["drink"] == "a" and data["more"] is True
+    with pytest.raises(vol.Invalid):
+        schema({"drink": "c"})
+
+
+def test_get_available_persons():
+    registry_entry = SimpleNamespace(
+        entity_id="person.one", domain="person", name="One", original_name=None
+    )
+    registry = SimpleNamespace(entities={"person.one": registry_entry})
+    state = SimpleNamespace(attributes={"user_id": "123"})
+    states = {"person.one": state}
+    persons = get_available_persons(registry, states, [PRICE_LIST_USER_EN])
+    assert persons == ["One"]
+    persons = get_available_persons(registry, states, ["One"])
+    assert persons == []


### PR DESCRIPTION
## Summary
- Extract flow step constants and helper utilities into `flow_helpers`
- Centralize drink and user management in new `TallyListFlowHandler`
- Split options flow into its own module and simplify `config_flow`
- Add unit tests for helper logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7650a5e8c832e9c201d406e26e6c0