### PR TITLE
feat: skip config flow for existing tally list

### DIFF
--- a/custom_components/tally_list/config_flow.py
+++ b/custom_components/tally_list/config_flow.py
@@ -90,6 +90,62 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return self.async_create_entry(title=self._user, data=user_input)
 
     async def async_step_user(self, user_input=None):
+        entries = self.hass.config_entries.async_entries(DOMAIN)
+        if entries:
+            registry = er.async_get(self.hass)
+            persons = [
+                entry.original_name or entry.name or entry.entity_id
+                for entry in registry.entities.values()
+                if entry.domain == "person"
+                and (
+                    (state := self.hass.states.get(entry.entity_id))
+                    and state.attributes.get("user_id")
+                )
+            ]
+
+            existing = {entry.data.get(CONF_USER) for entry in entries}
+
+            excluded = set(self.hass.data.get(DOMAIN, {}).get(CONF_EXCLUDED_USERS, []))
+
+            persons = [
+                p
+                for p in persons
+                if p not in existing and p not in excluded and p not in PRICE_LIST_USERS
+            ]
+
+            if persons:
+                data_template = {
+                    CONF_DRINKS: self.hass.data.get(DOMAIN, {}).get(CONF_DRINKS, {}),
+                    CONF_FREE_AMOUNT: float(
+                        self.hass.data.get(DOMAIN, {}).get(CONF_FREE_AMOUNT, 0.0)
+                    ),
+                    CONF_EXCLUDED_USERS: list(
+                        self.hass.data.get(DOMAIN, {}).get(CONF_EXCLUDED_USERS, [])
+                    ),
+                    CONF_OVERRIDE_USERS: list(
+                        self.hass.data.get(DOMAIN, {}).get(CONF_OVERRIDE_USERS, [])
+                    ),
+                    CONF_PUBLIC_DEVICES: list(
+                        self.hass.data.get(DOMAIN, {}).get(CONF_PUBLIC_DEVICES, [])
+                    ),
+                    CONF_CURRENCY: self.hass.data.get(DOMAIN, {}).get(CONF_CURRENCY, "€"),
+                    CONF_ENABLE_FREE_DRINKS: self.hass.data.get(DOMAIN, {}).get(
+                        CONF_ENABLE_FREE_DRINKS, False
+                    ),
+                    CONF_CASH_USER_NAME: get_cash_user_name(
+                        getattr(self.hass.config, "language", None)
+                    ),
+                }
+
+                for person in persons:
+                    data = {**data_template, CONF_USER: person}
+                    await self.hass.config_entries.flow.async_init(
+                        DOMAIN,
+                        context={"source": config_entries.SOURCE_IMPORT},
+                        data=data,
+                    )
+            return self.async_abort(reason="already_configured")
+
         if not self._user_selected:
             self._cash_user_name = get_cash_user_name(
                 getattr(self.hass.config, "language", None)
@@ -105,10 +161,7 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 )
             ]
 
-            existing = {
-                entry.data.get(CONF_USER)
-                for entry in self.hass.config_entries.async_entries(DOMAIN)
-            }
+            existing = {entry.data.get(CONF_USER) for entry in entries}
 
             excluded = set(self.hass.data.get(DOMAIN, {}).get(CONF_EXCLUDED_USERS, []))
             # Preserve already excluded users when the price list user is recreated
@@ -120,7 +173,6 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 if p not in existing and p not in excluded and p not in PRICE_LIST_USERS
             ]
 
-            entries = self.hass.config_entries.async_entries(DOMAIN)
             self._create_price_user = not any(
                 entry.data.get(CONF_USER) in PRICE_LIST_USERS for entry in entries
             )

--- a/custom_components/tally_list/manifest.json
+++ b/custom_components/tally_list/manifest.json
@@ -3,7 +3,7 @@
   "name": "Tally List",
   "documentation": "https://github.com/Spider19996/ha-tally-list",
   "issue_tracker": "https://github.com/Spider19996/ha-tally-list/issues",
-  "version": "02.09.2025",
+  "version": "06.09.2025",
   "requirements": [],
   "config_flow": true,
   "codeowners": ["@Spider19996"],

--- a/custom_components/tally_list/translations/de.json
+++ b/custom_components/tally_list/translations/de.json
@@ -3,7 +3,8 @@
   "config": {
     "title": "Strichliste",
     "abort": {
-      "no_users": "Keine Personen mit Benutzerkonto gefunden"
+      "no_users": "Keine Personen mit Benutzerkonto gefunden",
+      "already_configured": "Integration bereits eingerichtet; neue Nutzer automatisch hinzugefügt"
     },
     "step": {
       "menu": {

--- a/custom_components/tally_list/translations/en.json
+++ b/custom_components/tally_list/translations/en.json
@@ -3,7 +3,8 @@
   "config": {
     "title": "Tally List",
     "abort": {
-      "no_users": "No persons with a user account found"
+      "no_users": "No persons with a user account found",
+      "already_configured": "Integration already configured; added new users automatically"
     },
     "step": {
       "menu": {


### PR DESCRIPTION
## Summary
- bump integration version to 06.09.2025
- automatically add new users when adding integration again instead of reopening config flow
- add translations for new abort message

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbedd2e0c0832ebe267300277c116d