### PR TITLE
feat: skip config flow for existing tally list

### DIFF
--- a/custom_components/tally_list/manifest.json
+++ b/custom_components/tally_list/manifest.json
@@ -3,7 +3,7 @@
   "name": "Tally List",
   "documentation": "https://github.com/Spider19996/ha-tally-list",
   "issue_tracker": "https://github.com/Spider19996/ha-tally-list/issues",
-  "version": "02.09.2025",
+  "version": "06.09.2025",
   "requirements": [],
   "config_flow": true,
   "codeowners": ["@Spider19996"],

--- a/custom_components/tally_list/translations/de.json
+++ b/custom_components/tally_list/translations/de.json
@@ -3,7 +3,8 @@
   "config": {
     "title": "Strichliste",
     "abort": {
-      "no_users": "Keine Personen mit Benutzerkonto gefunden"
+      "no_users": "Keine Personen mit Benutzerkonto gefunden",
+      "already_configured": "Integration bereits eingerichtet; neue Nutzer automatisch hinzugefügt"
     },
     "step": {
       "menu": {

--- a/custom_components/tally_list/translations/en.json
+++ b/custom_components/tally_list/translations/en.json
@@ -3,7 +3,8 @@
   "config": {
     "title": "Tally List",
     "abort": {
-      "no_users": "No persons with a user account found"
+      "no_users": "No persons with a user account found",
+      "already_configured": "Integration already configured; added new users automatically"
     },
     "step": {
       "menu": {


### PR DESCRIPTION
## Summary
- bump integration version to 06.09.2025
- automatically add new users when adding integration again instead of reopening config flow
- add translations for new abort message
- avoid config flow crash by scheduling user import asynchronously

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbedd2e0c0832ebe267300277c116d