### PR TITLE
chore: bump version to 12.09.25

### DIFF
--- a/custom_components/tally_list/manifest.json
+++ b/custom_components/tally_list/manifest.json
@@ -3,7 +3,7 @@
   "name": "Tally List",
   "documentation": "https://github.com/Spider19996/ha-tally-list",
   "issue_tracker": "https://github.com/Spider19996/ha-tally-list/issues",
-  "version": "06.09.2025",
+  "version": "12.09.25",
   "requirements": [],
   "config_flow": true,
   "codeowners": ["@Spider19996"],


### PR DESCRIPTION
## Summary
- bump integration version to 12.09.25

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c459717400832ea110f4536e52bc67