### PR TITLE
Add credit tracking sensor and admin credit services

### DIFF
--- a/custom_components/tally_list/const.py
+++ b/custom_components/tally_list/const.py
@@ -20,6 +20,7 @@ ATTR_DRINK = "drink"
 ATTR_FREE_DRINK = "free_drink"
 ATTR_COMMENT = "comment"
 ATTR_PIN = "pin"
+ATTR_AMOUNT = "amount"
 
 SERVICE_ADD_DRINK = "add_drink"
 SERVICE_REMOVE_DRINK = "remove_drink"
@@ -27,6 +28,9 @@ SERVICE_ADJUST_COUNT = "adjust_count"
 SERVICE_RESET_COUNTERS = "reset_counters"
 SERVICE_EXPORT_CSV = "export_csv"
 SERVICE_SET_PIN = "set_pin"
+SERVICE_ADD_CREDIT = "add_credit"
+SERVICE_REMOVE_CREDIT = "remove_credit"
+SERVICE_SET_CREDIT = "set_credit"
 
 # Dedicated user name that exposes drink prices
 PRICE_LIST_USER_DE = "Preisliste"

--- a/custom_components/tally_list/manifest.json
+++ b/custom_components/tally_list/manifest.json
@@ -3,7 +3,7 @@
   "name": "Tally List",
   "documentation": "https://github.com/Spider19996/ha-tally-list",
   "issue_tracker": "https://github.com/Spider19996/ha-tally-list/issues",
-  "version": "12.09.25",
+  "version": "13.09.25",
   "requirements": [],
   "config_flow": true,
   "codeowners": ["@Spider19996"],

--- a/custom_components/tally_list/services.yaml
+++ b/custom_components/tally_list/services.yaml
@@ -168,3 +168,51 @@ set_pin:
       required: false
       selector:
         text:
+add_credit:
+  name: Add credit
+  description: Increase credit for a person
+  fields:
+    user:
+      description: Person name
+      required: true
+      selector:
+        text:
+    amount:
+      description: Amount to add
+      required: true
+      selector:
+        number:
+          min: 0
+          step: 0.01
+remove_credit:
+  name: Remove credit
+  description: Decrease credit for a person
+  fields:
+    user:
+      description: Person name
+      required: true
+      selector:
+        text:
+    amount:
+      description: Amount to remove
+      required: true
+      selector:
+        number:
+          min: 0
+          step: 0.01
+set_credit:
+  name: Set credit
+  description: Set credit for a person to an exact amount
+  fields:
+    user:
+      description: Person name
+      required: true
+      selector:
+        text:
+    amount:
+      description: New credit amount
+      required: true
+      selector:
+        number:
+          min: 0
+          step: 0.01

--- a/custom_components/tally_list/translations/de.json
+++ b/custom_components/tally_list/translations/de.json
@@ -453,6 +453,48 @@
           "description": "Neue vierstellige PIN (leer lassen zum Löschen)"
         }
       }
+    },
+    "add_credit": {
+      "name": "Guthaben hinzufügen",
+      "description": "Guthaben für eine Person erhöhen",
+      "fields": {
+        "user": {
+          "name": "Person",
+          "description": "Personenname"
+        },
+        "amount": {
+          "name": "Betrag",
+          "description": "Hinzugefügter Betrag"
+        }
+      }
+    },
+    "remove_credit": {
+      "name": "Guthaben verringern",
+      "description": "Guthaben für eine Person verringern",
+      "fields": {
+        "user": {
+          "name": "Person",
+          "description": "Personenname"
+        },
+        "amount": {
+          "name": "Betrag",
+          "description": "Abzuziehender Betrag"
+        }
+      }
+    },
+    "set_credit": {
+      "name": "Guthaben setzen",
+      "description": "Guthaben einer Person auf einen genauen Betrag setzen",
+      "fields": {
+        "user": {
+          "name": "Person",
+          "description": "Personenname"
+        },
+        "amount": {
+          "name": "Betrag",
+          "description": "Neuer Guthabenbetrag"
+        }
+      }
     }
   }
 }

--- a/custom_components/tally_list/translations/en.json
+++ b/custom_components/tally_list/translations/en.json
@@ -453,6 +453,48 @@
           "description": "New 4-digit PIN (leave empty to clear)"
         }
       }
+    },
+    "add_credit": {
+      "name": "Add credit",
+      "description": "Increase credit for a person",
+      "fields": {
+        "user": {
+          "name": "Person",
+          "description": "Person name"
+        },
+        "amount": {
+          "name": "Amount",
+          "description": "Amount to add"
+        }
+      }
+    },
+    "remove_credit": {
+      "name": "Remove credit",
+      "description": "Decrease credit for a person",
+      "fields": {
+        "user": {
+          "name": "Person",
+          "description": "Person name"
+        },
+        "amount": {
+          "name": "Amount",
+          "description": "Amount to remove"
+        }
+      }
+    },
+    "set_credit": {
+      "name": "Set credit",
+      "description": "Set credit for a person to an exact amount",
+      "fields": {
+        "user": {
+          "name": "Person",
+          "description": "Person name"
+        },
+        "amount": {
+          "name": "Amount",
+          "description": "New credit amount"
+        }
+      }
     }
   }
 }

--- a/tests/test_total_amount_sensor.py
+++ b/tests/test_total_amount_sensor.py
@@ -151,3 +151,19 @@ def test_total_amount_sensor_cash_user_ignores_free_amount():
     sensor = TotalAmountSensor(hass, entry)
     assert sensor.native_value == 2.0
 
+
+def test_total_amount_sensor_with_credit():
+    entry = DummyConfigEntry("def", "Alice")
+    hass = DummyHass(
+        {
+            DOMAIN: {
+                "drinks": {"Beer": 2.0},
+                "free_amount": 1.0,
+                CONF_CASH_USER_NAME: "Cash",
+                entry.entry_id: {"counts": {"Beer": 2}, "credit": 1.5},
+            }
+        }
+    )
+    sensor = TotalAmountSensor(hass, entry)
+    assert sensor.native_value == 1.5
+


### PR DESCRIPTION
## Summary
- add per-user credit sensor and adjust amount due calculation
- allow admins to manage credit via add, remove and set services
- reset credit alongside counters and update version to 13.09.25

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5cdfca9a4832e989353dd810711c6