### PR TITLE
Allow negative credit balance

### DIFF
--- a/custom_components/tally_list/__init__.py
+++ b/custom_components/tally_list/__init__.py
@@ -379,10 +379,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             raise HomeAssistantError(
                 translation_domain=DOMAIN, translation_key="user_unknown"
             )
-        credit = entry.setdefault("credit", 0.0) + amount
-        if credit < 0:
-            credit = 0.0
-        entry["credit"] = credit
+        entry["credit"] = entry.setdefault("credit", 0.0) + amount
         for sensor in entry.get("sensors", []):
             await sensor.async_update_state()
 
@@ -395,17 +392,14 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             raise HomeAssistantError(
                 translation_domain=DOMAIN, translation_key="user_unknown"
             )
-        credit = entry.setdefault("credit", 0.0) - amount
-        if credit < 0:
-            credit = 0.0
-        entry["credit"] = credit
+        entry["credit"] = entry.setdefault("credit", 0.0) - amount
         for sensor in entry.get("sensors", []):
             await sensor.async_update_state()
 
     async def set_credit_service(call):
         await _verify_permissions(call, None)
         user = call.data[ATTR_USER]
-        amount = max(0.0, float(call.data.get(ATTR_AMOUNT, 0.0)))
+        amount = float(call.data.get(ATTR_AMOUNT, 0.0))
         entry = _find_user_entry(user)
         if entry is None:
             raise HomeAssistantError(

--- a/custom_components/tally_list/services.yaml
+++ b/custom_components/tally_list/services.yaml
@@ -214,5 +214,4 @@ set_credit:
       required: true
       selector:
         number:
-          min: 0
           step: 0.01

--- a/tests/test_total_amount_sensor.py
+++ b/tests/test_total_amount_sensor.py
@@ -167,3 +167,19 @@ def test_total_amount_sensor_with_credit():
     sensor = TotalAmountSensor(hass, entry)
     assert sensor.native_value == 1.5
 
+
+def test_total_amount_sensor_with_negative_credit():
+    entry = DummyConfigEntry("ghi", "Alice")
+    hass = DummyHass(
+        {
+            DOMAIN: {
+                "drinks": {"Beer": 2.0},
+                "free_amount": 1.0,
+                CONF_CASH_USER_NAME: "Cash",
+                entry.entry_id: {"counts": {"Beer": 2}, "credit": -1.5},
+            }
+        }
+    )
+    sensor = TotalAmountSensor(hass, entry)
+    assert sensor.native_value == 4.5
+


### PR DESCRIPTION
## Summary
- Let credit values go negative in add, remove and set credit services
- Permit setting negative credit via service definitions
- Add test coverage for negative credit calculations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5d01390cc832ebd1c45c4227aec06