### PR TITLE
feat: show drink counts as history graphs

### DIFF
--- a/custom_components/tally_list/sensor.py
+++ b/custom_components/tally_list/sensor.py
@@ -117,7 +117,8 @@ class TallyListSensor(RestoreEntity, SensorEntity):
         user_slug = get_user_slug(hass, entry.data[CONF_USER])
         self.entity_id = f"sensor.{user_slug}_{slugify(drink)}_count"
         self._attr_native_value = 0
-        self._attr_native_unit_of_measurement = None
+        self._attr_native_unit_of_measurement = ""
+        self._attr_state_class = "measurement"
 
     async def async_added_to_hass(self) -> None:
         last_state = await self.async_get_last_state()
@@ -138,7 +139,7 @@ class TallyListSensor(RestoreEntity, SensorEntity):
         await self.async_update_state()
 
     async def async_update_state(self):
-        self._attr_native_unit_of_measurement = None
+        self._attr_native_unit_of_measurement = ""
         self.async_write_ha_state()
 
     @property


### PR DESCRIPTION
## Summary
- render drink count sensors with a unit and `measurement` state class so they display as history graphs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5d266025c832e8275b4e018052bc4