### PR TITLE
Use drink icons for price list sensors

### DIFF
--- a/custom_components/tally_list/sensor.py
+++ b/custom_components/tally_list/sensor.py
@@ -46,7 +46,11 @@ async def async_setup_entry(
 
     if user in PRICE_LIST_USERS:
         for drink_name, price in drinks.items():
-            sensors.append(DrinkPriceSensor(hass, entry, drink_name, price))
+            sensors.append(
+                DrinkPriceSensor(
+                    hass, entry, drink_name, price, icons.get(drink_name)
+                )
+            )
         sensors.append(FreeAmountSensor(hass, entry))
     else:
         for drink_name, price in drinks.items():
@@ -183,6 +187,7 @@ class DrinkPriceSensor(CurrencySensor):
         entry: ConfigEntry,
         drink: str,
         price: float,
+        icon: str | None = None,
     ) -> None:
         super().__init__(hass)
         self._entry = entry
@@ -195,6 +200,7 @@ class DrinkPriceSensor(CurrencySensor):
         self._attr_unique_id = f"{entry.entry_id}_{drink}_price"
         self.entity_id = f"sensor.price_list_{slugify(drink)}_price"
         self._attr_suggested_display_precision = 2
+        self._attr_icon = icon
 
     @property
     def native_value(self):

--- a/tests/test_total_amount_sensor.py
+++ b/tests/test_total_amount_sensor.py
@@ -107,6 +107,7 @@ CONF_USER = const.CONF_USER
 CONF_CASH_USER_NAME = const.CONF_CASH_USER_NAME
 TotalAmountSensor = sensor_module.TotalAmountSensor
 TallyListSensor = sensor_module.TallyListSensor
+DrinkPriceSensor = sensor_module.DrinkPriceSensor
 
 
 class DummyHass:
@@ -191,5 +192,12 @@ def test_tally_list_sensor_icon():
         {DOMAIN: {"drinks": {"Beer": 2.0}, "drink_icons": {"Beer": "mdi:beer"}, entry.entry_id: {"counts": {}}}}
     )
     sensor = TallyListSensor(hass, entry, "Beer", 2.0, "mdi:beer")
+    assert sensor._attr_icon == "mdi:beer"
+
+
+def test_drink_price_sensor_icon():
+    entry = DummyConfigEntry("mno", "Preisliste")
+    hass = DummyHass({DOMAIN: {"drinks": {"Beer": 2.0}}})
+    sensor = DrinkPriceSensor(hass, entry, "Beer", 2.0, "mdi:beer")
     assert sensor._attr_icon == "mdi:beer"
 


### PR DESCRIPTION
## Summary
- Ensure price list sensors show the same drink icons as count sensors
- Cover drink price sensor icons with a new unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5dc0d9084832ea3aa5318ebd363ed