### PR TITLE
Add icons for sensors and reset button

### DIFF
--- a/custom_components/tally_list/button.py
+++ b/custom_components/tally_list/button.py
@@ -34,6 +34,7 @@ class ResetButton(ButtonEntity):
         self._attr_unique_id = f"{entry.entry_id}_reset_tally"
         user_slug = get_user_slug(hass, user)
         self.entity_id = f"button.{user_slug}_reset_tally"
+        self._attr_icon = "mdi:refresh"
 
     async def async_press(self) -> None:
         user_id = self._context.user_id if self._context else None

--- a/custom_components/tally_list/sensor.py
+++ b/custom_components/tally_list/sensor.py
@@ -219,6 +219,7 @@ class FreeAmountSensor(CurrencySensor):
         self._attr_unique_id = f"{entry.entry_id}_free_amount"
         self.entity_id = "sensor.price_list_free_amount"
         self._attr_suggested_display_precision = 2
+        self._attr_icon = "mdi:star"
 
     @property
     def native_value(self):
@@ -238,6 +239,7 @@ class TotalAmountSensor(CurrencySensor, RestoreEntity):
         self.entity_id = f"sensor.{user_slug}_amount_due"
         self._attr_native_value = 0
         self._attr_suggested_display_precision = 2
+        self._attr_icon = "mdi:cash"
 
     @property
     def native_value(self):
@@ -272,6 +274,7 @@ class CreditSensor(CurrencySensor, RestoreEntity):
         self.entity_id = f"sensor.{user_slug}_credit"
         self._attr_native_value = 0.0
         self._attr_suggested_display_precision = 2
+        self._attr_icon = "mdi:bank"
 
     async def async_added_to_hass(self) -> None:
         await super().async_added_to_hass()
@@ -310,6 +313,7 @@ class FreeDrinkFeedSensor(SensorEntity):
         )
         self._entries: list[dict[str, str]] = []
         self._attr_native_value = "none"
+        self._attr_icon = "mdi:clipboard-list"
 
     async def async_added_to_hass(self) -> None:
         await self.async_update_state()


### PR DESCRIPTION
## Summary
- Set default icons for reset button and tally list sensors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5dcd3c7f0832e8e604bc9928c56d4