### PR TITLE
Add price list change feed and logging

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -48,6 +48,8 @@ Jede Person erhält eine Entität `button.<person>_reset_tally`, um ihre Zähler
 Alle Getränke werden in einer gemeinsamen Preisliste gespeichert. Ein spezieller Benutzer namens `Preisliste` (englisch `Price list`) stellt für jedes Getränk einen Preissensor sowie einen Sensor für den Freibetrag bereit, während normale Personen nur Zähl- und Gesamtbetragssensoren erhalten. Der Freibetrag wird vom Gesamtbetrag jeder Person abgezogen. Getränke, Preise und Freibetrag können jederzeit über die Integrationsoptionen bearbeitet werden.
 Die Sensoren des Preisliste-Benutzers verwenden immer englische Entitäts-IDs mit dem Präfix `price_list`, z. B. `sensor.price_list_free_amount` oder `sensor.price_list_wasser_price`.
 
+Jede Änderung an der Preisliste wird in jährlichen CSV-Dateien unter `/config/backup/tally_list/price_list/` protokolliert. Ein Feed-Sensor `sensor.price_list_feed` zeigt den letzten Eintrag an und stellt die jüngsten Änderungen in seinen Attributen bereit.
+
 ## Freigetränke (Optional)
 
 Wenn in den Integrationsoptionen aktiviert, können Freigetränke separat erfasst werden.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Each person gets a `button.<person>_reset_tally` entity to reset all their count
 All drinks are stored in a single price list. A dedicated user named `Preisliste` (`Price list` in English) exposes one price sensor per drink as well as a free amount sensor, while regular persons only get count and total amount sensors. The free amount is subtracted from each person's total. You can edit drinks, prices and the free amount at any time from the integration options.
 Sensors for the price list user always use English entity IDs prefixed with `price_list`, for example `sensor.price_list_free_amount` or `sensor.price_list_wasser_price`.
 
+Every change to the price list is written to yearly CSV logs under `/config/backup/tally_list/price_list/`. A feed sensor `sensor.price_list_feed` shows the latest entry and exposes recent changes in its attributes.
+
 ## Free Drinks (Optional)
 
 If enabled in the integration options, complimentary drinks are tracked separately.

--- a/custom_components/tally_list/__init__.py
+++ b/custom_components/tally_list/__init__.py
@@ -802,6 +802,13 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             hass.data[DOMAIN].pop("free_drink_feed_sensors", None)
             hass.data[DOMAIN].pop("feed_add_entities", None)
             hass.data[DOMAIN].pop("feed_entry_id", None)
+        if hass.data[DOMAIN].get("price_feed_entry_id") == entry.entry_id:
+            unsub = hass.data[DOMAIN].pop("price_feed_unsub", None)
+            if unsub is not None:
+                unsub()
+            hass.data[DOMAIN].pop("price_list_feed_sensor", None)
+            hass.data[DOMAIN].pop("price_feed_add_entities", None)
+            hass.data[DOMAIN].pop("price_feed_entry_id", None)
         hass.data[DOMAIN].pop(entry.entry_id, None)
         user_name = entry.data.get(CONF_USER)
         if user_name in PRICE_LIST_USERS:

--- a/custom_components/tally_list/config_flow.py
+++ b/custom_components/tally_list/config_flow.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import logging
+import os
+import csv
 import voluptuous as vol
 
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.selector import IconSelector
+from homeassistant.util import dt as dt_util
 
 from homeassistant import config_entries
 from homeassistant.core import callback
@@ -31,8 +34,61 @@ from .const import (
     get_cash_user_name,
 )
 
+from .utils import get_person_name
+from .sensor import PriceListFeedSensor
+
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _write_price_list_log(
+    hass, user: str, action: str, details: str
+) -> None:
+    tz = dt_util.get_time_zone("Europe/Berlin")
+    ts = dt_util.now(tz).replace(second=0, microsecond=0)
+    base_dir = hass.config.path("backup", "tally_list", "price_list")
+    os.makedirs(base_dir, exist_ok=True)
+    path = os.path.join(base_dir, f"price_list_{ts.year}.csv")
+    rows: list[list[str]] = []
+    if os.path.exists(path):
+        with open(path, "r", encoding="utf-8", newline="") as csvfile:
+            rows = list(csv.reader(csvfile, delimiter=";"))
+    if not rows:
+        rows = [["Time", "User", "Action", "Details"]]
+    key_time = ts.strftime("%Y-%m-%dT%H:%M")
+    rows.append([key_time, user, action, details])
+    with open(path, "w", encoding="utf-8", newline="") as csvfile:
+        writer = csv.writer(csvfile, delimiter=";", quoting=csv.QUOTE_MINIMAL)
+        writer.writerows(rows)
+
+
+async def _async_update_price_feed_sensor(hass) -> None:
+    sensor = hass.data[DOMAIN].get("price_list_feed_sensor")
+    if sensor is not None:
+        await sensor.async_update_state()
+        return
+    add_entities = hass.data[DOMAIN].get("price_feed_add_entities")
+    feed_entry_id = hass.data[DOMAIN].get("price_feed_entry_id")
+    entry = (
+        hass.config_entries.async_get_entry(feed_entry_id)
+        if feed_entry_id is not None
+        else None
+    )
+    if add_entities is not None and entry is not None:
+        sensor = PriceListFeedSensor(hass, entry)
+        hass.data[DOMAIN]["price_list_feed_sensor"] = sensor
+        add_entities([sensor])
+
+
+async def _log_price_change(hass, user_id, action: str, details: str) -> None:
+    hass_user = await hass.auth.async_get_user(user_id) if user_id else None
+    name = get_person_name(hass, user_id) or (
+        hass_user.name if hass_user else "Unknown"
+    )
+    await hass.async_add_executor_job(
+        _write_price_list_log, hass, name, action, details
+    )
+    await _async_update_price_feed_sensor(hass)
 
 
 def _parse_drinks(value: str) -> dict[str, float]:
@@ -308,6 +364,12 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             icon = user_input[CONF_ICON]
             self._drinks[drink] = price
             self._drink_icons[drink] = icon
+            await _log_price_change(
+                self.hass,
+                self.context.get("user_id"),
+                "add_drink",
+                f"{drink}={price}",
+            )
             if user_input.get("add_more"):
                 return await self.async_step_add_drink()
             return await self.async_step_menu()
@@ -326,6 +388,12 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             drink = user_input[CONF_DRINK]
             self._drinks.pop(drink, None)
             self._drink_icons.pop(drink, None)
+            await _log_price_change(
+                self.hass,
+                self.context.get("user_id"),
+                "remove_drink",
+                drink,
+            )
             if user_input.get("remove_more") and self._drinks:
                 return await self.async_step_remove_drink()
             return await self.async_step_menu()
@@ -345,8 +413,15 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 drink = self._edit_drink
                 price = float(user_input[CONF_PRICE])
                 icon = user_input[CONF_ICON]
+                old = self._drinks.get(drink)
                 self._drinks[drink] = price
                 self._drink_icons[drink] = icon
+                await _log_price_change(
+                    self.hass,
+                    self.context.get("user_id"),
+                    "edit_drink",
+                    f"{drink}:{old}->{price}",
+                )
                 self._edit_drink = None
                 if user_input.get("edit_more") and self._drinks:
                     return await self.async_step_edit_price()
@@ -372,7 +447,14 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_set_free_amount(self, user_input=None):
         if user_input is not None:
+            old = self._free_amount
             self._free_amount = float(user_input[CONF_FREE_AMOUNT])
+            await _log_price_change(
+                self.hass,
+                self.context.get("user_id"),
+                "free_amount",
+                f"{old}->{self._free_amount}",
+            )
             return await self.async_step_menu()
         schema = vol.Schema(
             {
@@ -849,6 +931,12 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
             icon = user_input[CONF_ICON]
             self._drinks[drink] = price
             self._drink_icons[drink] = icon
+            await _log_price_change(
+                self.hass,
+                self.context.get("user_id"),
+                "add_drink",
+                f"{drink}={price}",
+            )
             if user_input.get("add_more"):
                 return await self.async_step_add_drink()
             return await self.async_step_menu()
@@ -868,6 +956,12 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
             drink = user_input[CONF_DRINK]
             self._drinks.pop(drink, None)
             self._drink_icons.pop(drink, None)
+            await _log_price_change(
+                self.hass,
+                self.context.get("user_id"),
+                "remove_drink",
+                drink,
+            )
             if user_input.get("remove_more") and self._drinks:
                 return await self.async_step_remove_drink()
             return await self.async_step_menu()
@@ -889,8 +983,15 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
                 drink = self._edit_drink
                 price = float(user_input[CONF_PRICE])
                 icon = user_input[CONF_ICON]
+                old = self._drinks.get(drink)
                 self._drinks[drink] = price
                 self._drink_icons[drink] = icon
+                await _log_price_change(
+                    self.hass,
+                    self.context.get("user_id"),
+                    "edit_drink",
+                    f"{drink}:{old}->{price}",
+                )
                 self._edit_drink = None
                 if user_input.get("edit_more") and self._drinks:
                     return await self.async_step_edit_price()
@@ -918,7 +1019,14 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
 
     async def async_step_set_free_amount(self, user_input=None):
         if user_input is not None:
+            old = self._free_amount
             self._free_amount = float(user_input[CONF_FREE_AMOUNT])
+            await _log_price_change(
+                self.hass,
+                self.context.get("user_id"),
+                "free_amount",
+                f"{old}->{self._free_amount}",
+            )
             return await self.async_step_menu()
         schema = vol.Schema(
             {

--- a/tests/test_total_amount_sensor.py
+++ b/tests/test_total_amount_sensor.py
@@ -133,6 +133,7 @@ DrinkPriceSensor = sensor_module.DrinkPriceSensor
 FreeAmountSensor = sensor_module.FreeAmountSensor
 CreditSensor = sensor_module.CreditSensor
 FreeDrinkFeedSensor = sensor_module.FreeDrinkFeedSensor
+PriceListFeedSensor = sensor_module.PriceListFeedSensor
 ResetButton = button_module.ResetButton
 
 
@@ -256,6 +257,13 @@ def test_free_drink_feed_sensor_icon():
     hass = DummyHass({DOMAIN: {}})
     sensor = FreeDrinkFeedSensor(hass, entry, 2024)
     assert sensor.icon == "mdi:clipboard-list"
+
+
+def test_price_list_feed_sensor_icon():
+    entry = DummyConfigEntry("id6", "Preisliste")
+    hass = DummyHass({DOMAIN: {}})
+    sensor = PriceListFeedSensor(hass, entry)
+    assert sensor.icon == "mdi:clipboard-edit"
 
 
 def test_reset_button_icon():


### PR DESCRIPTION
## Summary
- track price list edits in yearly CSV logs and expose a continuous feed sensor
- log price list changes from config and options flows
- document price list feed

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5e2d1bc60832e833f9c5ea4a13a06