### PR TITLE
Fix missing user in price change log

### DIFF
--- a/custom_components/tally_list/config_flow.py
+++ b/custom_components/tally_list/config_flow.py
@@ -82,13 +82,15 @@ async def _async_update_price_feed_sensor(hass) -> None:
 
 async def _log_price_change(hass, user_id, action: str, details: str) -> None:
     auth = getattr(hass, "auth", None)
-    if user_id is None and auth is not None:
-        current = getattr(auth, "current_user", None)
-        if current is not None:
-            user_id = current.id
-    hass_user = (
-        await auth.async_get_user(user_id) if auth is not None and user_id else None
-    )
+    hass_user = None
+    if auth is not None:
+        if user_id:
+            hass_user = await auth.async_get_user(user_id)
+        if hass_user is None:
+            current = getattr(auth, "current_user", None)
+            if current is not None:
+                hass_user = current
+                user_id = current.id
     name = get_person_name(hass, user_id) or (
         hass_user.name if hass_user else "Unknown"
     )


### PR DESCRIPTION
## Summary
- ensure `_log_price_change` falls back to the current Home Assistant user when an unknown user ID is provided

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5e99af4ac832ebd569a24a2d96633