### PR TITLE
Persist free drink feed and reset with user

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -56,10 +56,11 @@ Wenn in den Integrationsoptionen aktiviert, können Freigetränke separat erfass
 Ein eigener Benutzer (Standardname `Freigetränke`, konfigurierbar) sammelt alle
 gratis gebuchten Getränke und stellt die gleichen Zähl- und Betragssensoren wie
 normale Nutzer bereit, z. B. `sensor.free_drinks_bier_count` und
-`sensor.free_drinks_amount_due`. Jeder Freigetränke-Eintrag wird in einer CSV-Datei
-unter `/config/backup/tally_list/free_drinks/` protokolliert. Für jedes Jahr
-entsteht ein Feed-Sensor wie `sensor.free_drink_feed_2024`, der den letzten Eintrag
-anzeigt und die jüngsten Freigetränke in seinen Attributen auflistet.
+`sensor.free_drinks_amount_due`. Jeder Freigetränke-Eintrag wird in einer
+jährlichen CSV-Datei `free_drinks_<Jahr>.csv` unter
+`/config/backup/tally_list/free_drinks/` protokolliert. Ein Feed-Sensor
+`sensor.free_drink_feed` zeigt den letzten Eintrag an und listet die jüngsten
+Freigetränke in seinen Attributen auf.
 
 Die Funktion kann in den Integrationsoptionen aktiviert oder deaktiviert und der
 Name des Freigetränke-Benutzers angepasst werden.

--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ If enabled in the integration options, complimentary drinks are tracked separate
 A dedicated user (default name `Free Drinks`, configurable) records all free
 drinks and exposes the same count and amount sensors as regular users, for
 example `sensor.free_drinks_beer_count` and `sensor.free_drinks_amount_due`.
-Each free drink entry is written to a CSV log under
-`/config/backup/tally_list/free_drinks/`. For every year a feed sensor such as
-`sensor.free_drink_feed_2024` is created that shows the latest log entry and
-lists recent free drinks in its attributes.
+Each free drink entry is written to yearly CSV files `free_drinks_<year>.csv`
+under `/config/backup/tally_list/free_drinks/`. A feed sensor
+`sensor.free_drink_feed` shows the latest log entry and lists recent free drinks
+in its attributes.
 
 You can activate or deactivate the feature and change the free drinks user name
 from the integration options.

--- a/tests/test_total_amount_sensor.py
+++ b/tests/test_total_amount_sensor.py
@@ -255,7 +255,7 @@ def test_credit_sensor_icon():
 def test_free_drink_feed_sensor_icon():
     entry = DummyConfigEntry("id4", "Cash")
     hass = DummyHass({DOMAIN: {}})
-    sensor = FreeDrinkFeedSensor(hass, entry, 2024)
+    sensor = FreeDrinkFeedSensor(hass, entry)
     assert sensor.icon == "mdi:clipboard-list"
 
 


### PR DESCRIPTION
## Summary
- Store free drink entries in yearly `free_drinks_<year>.csv` files and expose them via persistent `sensor.free_drink_feed`
- Clear all yearly free drink logs when the free drinks user is reset
- Update documentation for the yearly free drink logs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5f52441f4832e8f9ba89bc55ea4ae