### PR TITLE
Use /config/tally_list for saved files

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -36,7 +36,7 @@ Beim ersten Einrichten wirst du nach verfügbaren Getränken gefragt. Alle Perso
 - `tally_list.remove_drink`: verringert die Anzahl eines Getränks für eine Person (nie unter null; Anzahl kann angegeben werden).
 - `tally_list.adjust_count`: setzt die Anzahl eines Getränks auf einen bestimmten Wert.
 - `tally_list.reset_counters`: setzt alle Zähler für eine Person oder – ohne Angabe einer Person – für alle zurück.
-- `tally_list.export_csv`: exportiert alle `_amount_due`-Sensoren als CSV-Dateien (`daily`, `weekly`, `monthly` oder `manual`), gespeichert unter `/config/backup/tally_list/<type>/`.
+- `tally_list.export_csv`: exportiert alle `_amount_due`-Sensoren als CSV-Dateien (`daily`, `weekly`, `monthly` oder `manual`), gespeichert unter `/config/tally_list/<type>/`.
 - `tally_list.set_pin`: setzt oder entfernt eine persönliche vierstellige PIN aus Ziffern für öffentliche Geräte (Admins können PINs für andere Nutzer setzen).
 
 ### Reset-Schalter
@@ -48,7 +48,7 @@ Jede Person erhält eine Entität `button.<person>_reset_tally`, um ihre Zähler
 Alle Getränke werden in einer gemeinsamen Preisliste gespeichert. Ein spezieller Benutzer namens `Preisliste` (englisch `Price list`) stellt für jedes Getränk einen Preissensor sowie einen Sensor für den Freibetrag bereit, während normale Personen nur Zähl- und Gesamtbetragssensoren erhalten. Der Freibetrag wird vom Gesamtbetrag jeder Person abgezogen. Getränke, Preise und Freibetrag können jederzeit über die Integrationsoptionen bearbeitet werden.
 Die Sensoren des Preisliste-Benutzers verwenden immer englische Entitäts-IDs mit dem Präfix `price_list`, z. B. `sensor.price_list_free_amount` oder `sensor.price_list_wasser_price`.
 
-Jede Änderung an der Preisliste wird in jährlichen CSV-Dateien unter `/config/backup/tally_list/price_list/` protokolliert. Ein Feed-Sensor `sensor.price_list_feed` zeigt den letzten Eintrag an und stellt die jüngsten Änderungen in seinen Attributen bereit.
+Jede Änderung an der Preisliste wird in jährlichen CSV-Dateien unter `/config/tally_list/price_list/` protokolliert. Ein Feed-Sensor `sensor.price_list_feed` zeigt den letzten Eintrag an und stellt die jüngsten Änderungen in seinen Attributen bereit.
 
 ## Freigetränke (Optional)
 
@@ -58,7 +58,7 @@ gratis gebuchten Getränke und stellt die gleichen Zähl- und Betragssensoren wi
 normale Nutzer bereit, z. B. `sensor.free_drinks_bier_count` und
 `sensor.free_drinks_amount_due`. Jeder Freigetränke-Eintrag wird in einer
 jährlichen CSV-Datei `free_drinks_<Jahr>.csv` unter
-`/config/backup/tally_list/free_drinks/` protokolliert. Ein Feed-Sensor
+`/config/tally_list/free_drinks/` protokolliert. Ein Feed-Sensor
 `sensor.free_drink_feed` zeigt den letzten Eintrag an und listet die jüngsten
 Freigetränke in seinen Attributen auf.
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ At initial setup you will be asked to enter available drinks. All persons with a
 - `tally_list.remove_drink`: decrement drink count for a person (never below zero; optionally specify amount).
 - `tally_list.adjust_count`: set a drink count to a specific value.
 - `tally_list.reset_counters`: reset all counters for a person or for everyone if no user is specified.
-- `tally_list.export_csv`: export all `_amount_due` sensors to CSV files (`daily`, `weekly`, `monthly`, or `manual`) saved under `/config/backup/tally_list/<type>/`.
+- `tally_list.export_csv`: export all `_amount_due` sensors to CSV files (`daily`, `weekly`, `monthly`, or `manual`) saved under `/config/tally_list/<type>/`.
 - `tally_list.set_pin`: set or clear a personal 4-digit numeric PIN required for public devices (admins can set PINs for others).
 
 ### Reset Button
@@ -48,7 +48,7 @@ Each person gets a `button.<person>_reset_tally` entity to reset all their count
 All drinks are stored in a single price list. A dedicated user named `Preisliste` (`Price list` in English) exposes one price sensor per drink as well as a free amount sensor, while regular persons only get count and total amount sensors. The free amount is subtracted from each person's total. You can edit drinks, prices and the free amount at any time from the integration options.
 Sensors for the price list user always use English entity IDs prefixed with `price_list`, for example `sensor.price_list_free_amount` or `sensor.price_list_wasser_price`.
 
-Every change to the price list is written to yearly CSV logs under `/config/backup/tally_list/price_list/`. A feed sensor `sensor.price_list_feed` shows the latest entry and exposes recent changes in its attributes.
+Every change to the price list is written to yearly CSV logs under `/config/tally_list/price_list/`. A feed sensor `sensor.price_list_feed` shows the latest entry and exposes recent changes in its attributes.
 
 ## Free Drinks (Optional)
 
@@ -57,7 +57,7 @@ A dedicated user (default name `Free Drinks`, configurable) records all free
 drinks and exposes the same count and amount sensors as regular users, for
 example `sensor.free_drinks_beer_count` and `sensor.free_drinks_amount_due`.
 Each free drink entry is written to yearly CSV files `free_drinks_<year>.csv`
-under `/config/backup/tally_list/free_drinks/`. A feed sensor
+under `/config/tally_list/free_drinks/`. A feed sensor
 `sensor.free_drink_feed` shows the latest log entry and lists recent free drinks
 in its attributes.
 

--- a/custom_components/tally_list/__init__.py
+++ b/custom_components/tally_list/__init__.py
@@ -137,7 +137,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     def _write_free_drink_log(name: str, drink: str, count: int, comment: str) -> None:
         tz = dt_util.get_time_zone("Europe/Berlin")
         ts = dt_util.now(tz).replace(second=0, microsecond=0)
-        base_dir = hass.config.path("backup", "tally_list", "free_drinks")
+        base_dir = hass.config.path("tally_list", "free_drinks")
         os.makedirs(base_dir, exist_ok=True)
         year = ts.strftime("%Y")
         path = os.path.join(base_dir, f"free_drinks_{year}.csv")
@@ -477,7 +477,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         if user is None or user == hass.data[DOMAIN].get(CONF_CASH_USER_NAME):
             hass.data[DOMAIN]["free_drink_counts"] = {}
             hass.data[DOMAIN]["free_drinks_ledger"] = 0.0
-            base_dir = hass.config.path("backup", "tally_list", "free_drinks")
+            base_dir = hass.config.path("tally_list", "free_drinks")
             if os.path.isdir(base_dir):
                 for name in os.listdir(base_dir):
                     if not re.match(r"free_drinks_\d{4}\.csv$", name):
@@ -506,7 +506,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         )
         currency = hass.data.get(DOMAIN, {}).get(CONF_CURRENCY, "€")
         now = dt_now()
-        base_dir = hass.config.path("backup", "tally_list")
+        base_dir = hass.config.path("tally_list")
 
         def _write_csv(path: str) -> None:
             os.makedirs(os.path.dirname(path), exist_ok=True)

--- a/custom_components/tally_list/config_flow.py
+++ b/custom_components/tally_list/config_flow.py
@@ -46,7 +46,7 @@ def _write_price_list_log(
 ) -> None:
     tz = dt_util.get_time_zone("Europe/Berlin")
     ts = dt_util.now(tz).replace(second=0, microsecond=0)
-    base_dir = hass.config.path("backup", "tally_list", "price_list")
+    base_dir = hass.config.path("tally_list", "price_list")
     os.makedirs(base_dir, exist_ok=True)
     path = os.path.join(base_dir, f"price_list_{ts.year}.csv")
     rows: list[list[str]] = []

--- a/custom_components/tally_list/sensor.py
+++ b/custom_components/tally_list/sensor.py
@@ -324,7 +324,7 @@ class FreeDrinkFeedSensor(SensorEntity):
         )
         self.entity_id = "sensor.free_drink_feed"
         self._attr_unique_id = f"{entry.entry_id}_free_drink_feed"
-        self._base_dir = hass.config.path("backup", "tally_list", "free_drinks")
+        self._base_dir = hass.config.path("tally_list", "free_drinks")
         self._entries: list[dict[str, str]] = []
         self._attr_native_value = "none"
         self._attr_icon = "mdi:clipboard-list"
@@ -408,7 +408,7 @@ class PriceListFeedSensor(SensorEntity):
         self._attr_name = _local_suffix(hass, "Price list feed", "Preisliste Feed")
         self.entity_id = "sensor.price_list_feed"
         self._attr_unique_id = f"{entry.entry_id}_price_list_feed"
-        self._base_dir = hass.config.path("backup", "tally_list", "price_list")
+        self._base_dir = hass.config.path("tally_list", "price_list")
         self._entries: list[dict[str, str]] = []
         self._attr_native_value = "none"
         self._attr_icon = "mdi:clipboard-edit"


### PR DESCRIPTION
## Summary
- Store free drink logs, price list logs, and CSV exports directly under `/config/tally_list/`
- Update documentation to remove `backup` directory from paths

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5f81eaefc832e853614fe9fca64e5