### PR TITLE
Align log action names with service functions

### DIFF
--- a/custom_components/tally_list/__init__.py
+++ b/custom_components/tally_list/__init__.py
@@ -276,7 +276,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         await _log_price_change(
             hass,
             call.context.user_id,
-            "set_count",
+            "adjust_count",
             f"{user}:{drink}={count}",
         )
 
@@ -328,7 +328,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             await _log_price_change(
                 hass,
                 call.context.user_id,
-                "book_free_drink",
+                "add_drink",
                 f"{user}:{drink}+{count}",
             )
             return
@@ -340,7 +340,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         await _log_price_change(
             hass,
             call.context.user_id,
-            "book_drink",
+            "add_drink",
             f"{user}:{drink}+{count}",
         )
 
@@ -382,7 +382,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             await _log_price_change(
                 hass,
                 call.context.user_id,
-                "remove_free_drink",
+                "remove_drink",
                 f"{user}:{drink}-{count}",
             )
             return

--- a/custom_components/tally_list/config_flow.py
+++ b/custom_components/tally_list/config_flow.py
@@ -499,7 +499,7 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             await _log_price_change(
                 self.hass,
                 self.context.get("user_id"),
-                "free_amount",
+                "set_free_amount",
                 f"{old}->{self._free_amount}",
             )
             return await self.async_step_menu()
@@ -1071,7 +1071,7 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
             await _log_price_change(
                 self.hass,
                 self.context.get("user_id"),
-                "free_amount",
+                "set_free_amount",
                 f"{old}->{self._free_amount}",
             )
             return await self.async_step_menu()

--- a/tests/test_price_list_log.py
+++ b/tests/test_price_list_log.py
@@ -99,9 +99,9 @@ def test_group_drinks_same_minute(tmp_path):
         tz = ZoneInfo("Europe/Berlin")
         ts = datetime(2025, 9, 14, 1, 9, 30, tzinfo=tz)
         with patch("tally_list.config_flow.dt_util.now", return_value=ts):
-            _write_price_list_log(hass, "Robin Zimmermann", "book_free_drink", "Robin Zimmermann:Bier+1")
-            _write_price_list_log(hass, "Robin Zimmermann", "book_free_drink", "Robin Zimmermann:Limo+1")
-            _write_price_list_log(hass, "Robin Zimmermann", "book_free_drink", "Robin Zimmermann:Wasser+1")
+            _write_price_list_log(hass, "Robin Zimmermann", "add_drink", "Robin Zimmermann:Bier+1")
+            _write_price_list_log(hass, "Robin Zimmermann", "add_drink", "Robin Zimmermann:Limo+1")
+            _write_price_list_log(hass, "Robin Zimmermann", "add_drink", "Robin Zimmermann:Wasser+1")
         path = Path(tmp_path, "tally_list", "price_list", "price_list_2025.csv")
         with path.open(newline="", encoding="utf-8") as f:
             rows = list(csv.reader(f, delimiter=";"))
@@ -109,7 +109,7 @@ def test_group_drinks_same_minute(tmp_path):
         assert rows[1] == [
             "2025-09-14T01:09",
             "Robin Zimmermann",
-            "book_free_drink",
+            "add_drink",
             "Robin Zimmermann:Bier+1,Limo+1,Wasser+1",
         ]
         assert len(rows) == 2
@@ -127,7 +127,7 @@ def test_aggregate_same_drink(tmp_path):
                 _write_price_list_log(
                     hass,
                     "Robin Zimmermann",
-                    "book_drink",
+                    "add_drink",
                     "Robin Zimmermann:Bier+1",
                 )
         path = Path(tmp_path, "tally_list", "price_list", "price_list_2025.csv")
@@ -136,7 +136,7 @@ def test_aggregate_same_drink(tmp_path):
         assert rows[1] == [
             "2025-09-14T01:22",
             "Robin Zimmermann",
-            "book_drink",
+            "add_drink",
             "Robin Zimmermann:Bier+4",
         ]
     finally:


### PR DESCRIPTION
## Summary
- rename logged actions to match service names like `add_drink`, `remove_drink`, `adjust_count`
- log free amount changes as `set_free_amount`
- update tests for new action names

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6020f1278832e973ff26e8bcd9caf