### PR TITLE
Log free drinks separately in price list log

### DIFF
--- a/custom_components/tally_list/__init__.py
+++ b/custom_components/tally_list/__init__.py
@@ -328,7 +328,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             await _log_price_change(
                 hass,
                 call.context.user_id,
-                "add_drink",
+                "add_free_drink",
                 f"{user}:{drink}+{count}",
             )
             return
@@ -382,7 +382,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             await _log_price_change(
                 hass,
                 call.context.user_id,
-                "remove_drink",
+                "remove_free_drink",
                 f"{user}:{drink}-{count}",
             )
             return


### PR DESCRIPTION
## Summary
- log free drink additions with action `add_free_drink`
- log free drink removals with action `remove_free_drink`
- test that free drinks are recorded separately in price list logs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c68d188b80832eaa2d412f98914517