### PR TITLE
Rename adjust_count service to set_drink

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -34,7 +34,7 @@ Beim ersten Einrichten wirst du nach verfügbaren Getränken gefragt. Alle Perso
 
 - `tally_list.add_drink`: erhöht die Anzahl eines Getränks für eine Person (schlägt fehl, wenn die Person nicht existiert; Anzahl kann angegeben werden).
 - `tally_list.remove_drink`: verringert die Anzahl eines Getränks für eine Person (nie unter null; Anzahl kann angegeben werden).
-- `tally_list.adjust_count`: setzt die Anzahl eines Getränks auf einen bestimmten Wert.
+- `tally_list.set_drink`: setzt die Anzahl eines Getränks auf einen bestimmten Wert.
 - `tally_list.reset_counters`: setzt alle Zähler für eine Person oder – ohne Angabe einer Person – für alle zurück.
 - `tally_list.export_csv`: exportiert alle `_amount_due`-Sensoren als CSV-Dateien (`daily`, `weekly`, `monthly` oder `manual`), gespeichert unter `/config/tally_list/<type>/`.
 - `tally_list.set_pin`: setzt oder entfernt eine persönliche vierstellige PIN aus Ziffern für öffentliche Geräte (Admins können PINs für andere Nutzer setzen).

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ At initial setup you will be asked to enter available drinks. All persons with a
 
 - `tally_list.add_drink`: increment drink count for a person (fails if the person does not exist; optionally specify amount).
 - `tally_list.remove_drink`: decrement drink count for a person (never below zero; optionally specify amount).
-- `tally_list.adjust_count`: set a drink count to a specific value.
+- `tally_list.set_drink`: set a drink count to a specific value.
 - `tally_list.reset_counters`: reset all counters for a person or for everyone if no user is specified.
 - `tally_list.export_csv`: export all `_amount_due` sensors to CSV files (`daily`, `weekly`, `monthly`, or `manual`) saved under `/config/tally_list/<type>/`.
 - `tally_list.set_pin`: set or clear a personal 4-digit numeric PIN required for public devices (admins can set PINs for others).

--- a/custom_components/tally_list/__init__.py
+++ b/custom_components/tally_list/__init__.py
@@ -26,7 +26,7 @@ from .const import (
     DOMAIN,
     SERVICE_ADD_DRINK,
     SERVICE_REMOVE_DRINK,
-    SERVICE_ADJUST_COUNT,
+    SERVICE_SET_DRINK,
     SERVICE_RESET_COUNTERS,
     SERVICE_EXPORT_CSV,
     SERVICE_SET_PIN,
@@ -259,7 +259,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             f"{target_user}:{'set' if pin else 'cleared'}",
         )
 
-    async def adjust_count_service(call):
+    async def set_drink_service(call):
         user = call.data[ATTR_USER]
         await _verify_permissions(call, user)
         drink = call.data[ATTR_DRINK]
@@ -276,7 +276,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         await _log_price_change(
             hass,
             call.context.user_id,
-            "adjust_count",
+            "set_drink",
             f"{user}:{drink}={count}",
         )
 
@@ -627,8 +627,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     hass.services.async_register(
         DOMAIN,
-        SERVICE_ADJUST_COUNT,
-        adjust_count_service,
+        SERVICE_SET_DRINK,
+        set_drink_service,
     )
 
     hass.services.async_register(

--- a/custom_components/tally_list/const.py
+++ b/custom_components/tally_list/const.py
@@ -26,7 +26,7 @@ ATTR_AMOUNT = "amount"
 
 SERVICE_ADD_DRINK = "add_drink"
 SERVICE_REMOVE_DRINK = "remove_drink"
-SERVICE_ADJUST_COUNT = "adjust_count"
+SERVICE_SET_DRINK = "set_drink"
 SERVICE_RESET_COUNTERS = "reset_counters"
 SERVICE_EXPORT_CSV = "export_csv"
 SERVICE_SET_PIN = "set_pin"

--- a/custom_components/tally_list/services.yaml
+++ b/custom_components/tally_list/services.yaml
@@ -76,8 +76,8 @@ remove_drink:
       required: false
       selector:
         text:
-adjust_count:
-  name: Adjust count
+set_drink:
+  name: Set drink
   description: Set drink count for a person
   fields:
     user:

--- a/custom_components/tally_list/translations/de.json
+++ b/custom_components/tally_list/translations/de.json
@@ -390,8 +390,8 @@
         }
       }
     },
-    "adjust_count": {
-      "name": "Zähler anpassen",
+    "set_drink": {
+      "name": "Getränkeanzahl setzen",
       "description": "Setzt den Getränkezähler für eine Person",
       "fields": {
         "user": {

--- a/custom_components/tally_list/translations/en.json
+++ b/custom_components/tally_list/translations/en.json
@@ -390,8 +390,8 @@
         }
       }
     },
-    "adjust_count": {
-      "name": "Adjust count",
+    "set_drink": {
+      "name": "Set drink",
       "description": "Set drink count for a person",
       "fields": {
         "user": {


### PR DESCRIPTION
## Summary
- rename `adjust_count` service to `set_drink`
- update logging, service definitions and translations
- adjust README documentation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c691d27eb0832ea08234e97c2ad575