### PR TITLE
Log user for drink price edits and skip unchanged logs

### DIFF
--- a/custom_components/tally_list/config_flow.py
+++ b/custom_components/tally_list/config_flow.py
@@ -138,6 +138,14 @@ async def _log_price_change(hass, user_id, action: str, details: str) -> None:
     await _async_update_price_feed_sensor(hass)
 
 
+def _get_flow_user_id(hass, context) -> str | None:
+    auth = getattr(hass, "auth", None)
+    current = getattr(auth, "current_user", None) if auth is not None else None
+    if current is not None:
+        return current.id
+    return context.get("user_id") if context is not None else None
+
+
 def _parse_drinks(value: str) -> dict[str, float]:
     drinks: dict[str, float] = {}
     if not value:
@@ -463,12 +471,14 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 old = self._drinks.get(drink)
                 self._drinks[drink] = price
                 self._drink_icons[drink] = icon
-                await _log_price_change(
-                    self.hass,
-                    self.context.get("user_id"),
-                    "edit_drink",
-                    f"{drink}:{old}->{price}",
-                )
+                user_id = _get_flow_user_id(self.hass, self.context)
+                if old != price:
+                    await _log_price_change(
+                        self.hass,
+                        user_id,
+                        "edit_drink",
+                        f"{drink}:{old}->{price}",
+                    )
                 self._edit_drink = None
                 if user_input.get("edit_more") and self._drinks:
                     return await self.async_step_edit_price()
@@ -1033,12 +1043,14 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
                 old = self._drinks.get(drink)
                 self._drinks[drink] = price
                 self._drink_icons[drink] = icon
-                await _log_price_change(
-                    self.hass,
-                    self.context.get("user_id"),
-                    "edit_drink",
-                    f"{drink}:{old}->{price}",
-                )
+                user_id = _get_flow_user_id(self.hass, self.context)
+                if old != price:
+                    await _log_price_change(
+                        self.hass,
+                        user_id,
+                        "edit_drink",
+                        f"{drink}:{old}->{price}",
+                    )
                 self._edit_drink = None
                 if user_input.get("edit_more") and self._drinks:
                     return await self.async_step_edit_price()

--- a/tests/test_price_list_log.py
+++ b/tests/test_price_list_log.py
@@ -4,9 +4,10 @@ import csv
 from pathlib import Path
 from datetime import datetime
 from zoneinfo import ZoneInfo
-from unittest.mock import patch
+from unittest.mock import patch, AsyncMock
 import importlib.machinery
 from importlib import import_module
+import pytest
 
 
 def _setup_env(tmp_path):
@@ -70,7 +71,10 @@ def _setup_env(tmp_path):
 
     # Import module under test
     config_flow = import_module("tally_list.config_flow")
+    const_mod = import_module("tally_list.const")
     _write_price_list_log = config_flow._write_price_list_log
+    _log_price_change = config_flow._log_price_change
+    OptionsFlowHandler = config_flow.TallyListOptionsFlowHandler
 
     class DummyConfig:
         def __init__(self, base_path):
@@ -90,11 +94,18 @@ def _setup_env(tmp_path):
         for mod in set(sys.modules.keys()) - original_modules:
             del sys.modules[mod]
 
-    return hass, _write_price_list_log, _cleanup
+    return (
+        hass,
+        _write_price_list_log,
+        _log_price_change,
+        OptionsFlowHandler,
+        const_mod,
+        _cleanup,
+    )
 
 
 def test_group_drinks_same_minute(tmp_path):
-    hass, _write_price_list_log, cleanup = _setup_env(tmp_path)
+    hass, _write_price_list_log, _, _, _, cleanup = _setup_env(tmp_path)
     try:
         tz = ZoneInfo("Europe/Berlin")
         ts = datetime(2025, 9, 14, 1, 9, 30, tzinfo=tz)
@@ -118,7 +129,7 @@ def test_group_drinks_same_minute(tmp_path):
 
 
 def test_aggregate_same_drink(tmp_path):
-    hass, _write_price_list_log, cleanup = _setup_env(tmp_path)
+    hass, _write_price_list_log, _, _, _, cleanup = _setup_env(tmp_path)
     try:
         tz = ZoneInfo("Europe/Berlin")
         ts = datetime(2025, 9, 14, 1, 22, 15, tzinfo=tz)
@@ -144,7 +155,7 @@ def test_aggregate_same_drink(tmp_path):
 
 
 def test_free_drink_logged_separately(tmp_path):
-    hass, _write_price_list_log, cleanup = _setup_env(tmp_path)
+    hass, _write_price_list_log, _, _, _, cleanup = _setup_env(tmp_path)
     try:
         tz = ZoneInfo("Europe/Berlin")
         ts = datetime(2025, 9, 14, 1, 9, 30, tzinfo=tz)
@@ -177,5 +188,54 @@ def test_free_drink_logged_separately(tmp_path):
             "Robin Zimmermann:Bier+1",
         ]
         assert len(rows) == 3
+    finally:
+        cleanup()
+
+
+@pytest.mark.asyncio
+async def test_log_when_price_changed(tmp_path):
+    hass, _, _, OptionsFlowHandler, const, cleanup = _setup_env(tmp_path)
+    try:
+        hass.auth = types.SimpleNamespace(current_user=types.SimpleNamespace(id="user-1"))
+        flow = OptionsFlowHandler(config_entry=None)
+        flow.hass = hass
+        flow.context = {}
+        flow.async_step_menu = AsyncMock(return_value=None)
+        flow._drinks = {"Bier": 1.6}
+        flow._drink_icons = {"Bier": "mdi:beer"}
+        flow._edit_drink = "Bier"
+        with patch("tally_list.config_flow._log_price_change", AsyncMock()) as log_mock:
+            await flow.async_step_edit_price({
+                const.CONF_PRICE: 1.7,
+                const.CONF_ICON: "mdi:beer",
+            })
+            log_mock.assert_awaited_once_with(
+                hass,
+                "user-1",
+                "edit_drink",
+                "Bier:1.6->1.7",
+            )
+    finally:
+        cleanup()
+
+
+@pytest.mark.asyncio
+async def test_no_log_when_price_unchanged(tmp_path):
+    hass, _, _, OptionsFlowHandler, const, cleanup = _setup_env(tmp_path)
+    try:
+        hass.auth = types.SimpleNamespace(current_user=types.SimpleNamespace(id="user-1"))
+        flow = OptionsFlowHandler(config_entry=None)
+        flow.hass = hass
+        flow.context = {}
+        flow.async_step_menu = AsyncMock(return_value=None)
+        flow._drinks = {"Bier": 1.6}
+        flow._drink_icons = {"Bier": "mdi:beer"}
+        flow._edit_drink = "Bier"
+        with patch("tally_list.config_flow._log_price_change", AsyncMock()) as log_mock:
+            await flow.async_step_edit_price({
+                const.CONF_PRICE: 1.6,
+                const.CONF_ICON: "mdi:beer",
+            })
+            log_mock.assert_not_called()
     finally:
         cleanup()


### PR DESCRIPTION
## Summary
- ensure drink price changes are attributed to the current user
- avoid logging when a drink price remains unchanged
- add tests for editing prices via options flow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c694b00814832eb6f46d2c5104a5de