### PR TITLE
Log user for drink price edits and skip unchanged logs

### DIFF
--- a/custom_components/tally_list/config_flow.py
+++ b/custom_components/tally_list/config_flow.py
@@ -129,13 +129,28 @@ async def _log_price_change(hass, user_id, action: str, details: str) -> None:
     hass_user = (
         await auth.async_get_user(user_id) if auth is not None and user_id else None
     )
-    name = get_person_name(hass, user_id) or (
-        hass_user.name if hass_user else "Unknown"
+    name = (
+        get_person_name(hass, user_id)
+        or (hass_user.name if hass_user and getattr(hass_user, "name", None) else None)
+        or (
+            hass_user.username
+            if hass_user and getattr(hass_user, "username", None)
+            else None
+        )
+        or "Unknown"
     )
     await hass.async_add_executor_job(
         _write_price_list_log, hass, name, action, details
     )
     await _async_update_price_feed_sensor(hass)
+
+
+def _get_flow_user_id(hass, context) -> str | None:
+    if context is not None and context.get("user_id"):
+        return context["user_id"]
+    auth = getattr(hass, "auth", None)
+    current = getattr(auth, "current_user", None) if auth is not None else None
+    return current.id if current is not None else None
 
 
 def _parse_drinks(value: str) -> dict[str, float]:
@@ -173,6 +188,11 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._enable_free_drinks: bool = False
         self._cash_user_name: str = get_cash_user_name(None)
         self._edit_drink: str | None = None
+        self._user_id: str | None = None
+
+    def _ensure_user_id(self) -> None:
+        if self._user_id is None:
+            self._user_id = _get_flow_user_id(self.hass, self.context)
 
     async def async_step_import(self, user_input=None):
         """Handle import of a config entry."""
@@ -201,6 +221,7 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return self.async_create_entry(title=self._user, data=user_input)
 
     async def async_step_user(self, user_input=None):
+        self._ensure_user_id()
         entries = self.hass.config_entries.async_entries(DOMAIN)
         if entries:
             registry = er.async_get(self.hass)
@@ -411,9 +432,10 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             icon = user_input[CONF_ICON]
             self._drinks[drink] = price
             self._drink_icons[drink] = icon
+            self._ensure_user_id()
             await _log_price_change(
                 self.hass,
-                self.context.get("user_id"),
+                self._user_id,
                 "add_drink",
                 f"{drink}={price}",
             )
@@ -435,9 +457,10 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             drink = user_input[CONF_DRINK]
             self._drinks.pop(drink, None)
             self._drink_icons.pop(drink, None)
+            self._ensure_user_id()
             await _log_price_change(
                 self.hass,
-                self.context.get("user_id"),
+                self._user_id,
                 "remove_drink",
                 drink,
             )
@@ -463,12 +486,14 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 old = self._drinks.get(drink)
                 self._drinks[drink] = price
                 self._drink_icons[drink] = icon
-                await _log_price_change(
-                    self.hass,
-                    self.context.get("user_id"),
-                    "edit_drink",
-                    f"{drink}:{old}->{price}",
-                )
+                if old != price:
+                    self._ensure_user_id()
+                    await _log_price_change(
+                        self.hass,
+                        self._user_id,
+                        "edit_drink",
+                        f"{drink}:{old}->{price}",
+                    )
                 self._edit_drink = None
                 if user_input.get("edit_more") and self._drinks:
                     return await self.async_step_edit_price()
@@ -496,9 +521,10 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             old = self._free_amount
             self._free_amount = float(user_input[CONF_FREE_AMOUNT])
+            self._ensure_user_id()
             await _log_price_change(
                 self.hass,
-                self.context.get("user_id"),
+                self._user_id,
                 "set_free_amount",
                 f"{old}->{self._free_amount}",
             )
@@ -784,6 +810,7 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
 
     def __init__(self, config_entry):
         self.config_entry = config_entry
+        self._user_id: str | None = None
         self._drinks: dict[str, float] = {}
         self._drink_icons: dict[str, str] = {}
         self._free_amount: float = 0.0
@@ -795,7 +822,12 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
         self._cash_user_name: str = get_cash_user_name(None)
         self._edit_drink: str | None = None
 
+    def _ensure_user_id(self) -> None:
+        if self._user_id is None:
+            self._user_id = _get_flow_user_id(self.hass, self.context)
+
     async def async_step_init(self, user_input=None):
+        self._user_id = _get_flow_user_id(self.hass, self.context)
         self._drinks = self.hass.data.get(DOMAIN, {}).get("drinks", {}).copy()
         self._drink_icons = (
             self.hass.data.get(DOMAIN, {}).get("drink_icons", {})
@@ -978,9 +1010,10 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
             icon = user_input[CONF_ICON]
             self._drinks[drink] = price
             self._drink_icons[drink] = icon
+            self._ensure_user_id()
             await _log_price_change(
                 self.hass,
-                self.context.get("user_id"),
+                self._user_id,
                 "add_drink",
                 f"{drink}={price}",
             )
@@ -1003,9 +1036,10 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
             drink = user_input[CONF_DRINK]
             self._drinks.pop(drink, None)
             self._drink_icons.pop(drink, None)
+            self._ensure_user_id()
             await _log_price_change(
                 self.hass,
-                self.context.get("user_id"),
+                self._user_id,
                 "remove_drink",
                 drink,
             )
@@ -1033,12 +1067,14 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
                 old = self._drinks.get(drink)
                 self._drinks[drink] = price
                 self._drink_icons[drink] = icon
-                await _log_price_change(
-                    self.hass,
-                    self.context.get("user_id"),
-                    "edit_drink",
-                    f"{drink}:{old}->{price}",
-                )
+                if old != price:
+                    self._ensure_user_id()
+                    await _log_price_change(
+                        self.hass,
+                        self._user_id,
+                        "edit_drink",
+                        f"{drink}:{old}->{price}",
+                    )
                 self._edit_drink = None
                 if user_input.get("edit_more") and self._drinks:
                     return await self.async_step_edit_price()
@@ -1068,9 +1104,10 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
         if user_input is not None:
             old = self._free_amount
             self._free_amount = float(user_input[CONF_FREE_AMOUNT])
+            self._ensure_user_id()
             await _log_price_change(
                 self.hass,
-                self.context.get("user_id"),
+                self._user_id,
                 "set_free_amount",
                 f"{old}->{self._free_amount}",
             )

--- a/tests/test_price_list_log.py
+++ b/tests/test_price_list_log.py
@@ -4,9 +4,10 @@ import csv
 from pathlib import Path
 from datetime import datetime
 from zoneinfo import ZoneInfo
-from unittest.mock import patch
+from unittest.mock import patch, AsyncMock
 import importlib.machinery
 from importlib import import_module
+import pytest
 
 
 def _setup_env(tmp_path):
@@ -70,7 +71,10 @@ def _setup_env(tmp_path):
 
     # Import module under test
     config_flow = import_module("tally_list.config_flow")
+    const_mod = import_module("tally_list.const")
     _write_price_list_log = config_flow._write_price_list_log
+    _log_price_change = config_flow._log_price_change
+    OptionsFlowHandler = config_flow.TallyListOptionsFlowHandler
 
     class DummyConfig:
         def __init__(self, base_path):
@@ -90,11 +94,18 @@ def _setup_env(tmp_path):
         for mod in set(sys.modules.keys()) - original_modules:
             del sys.modules[mod]
 
-    return hass, _write_price_list_log, _cleanup
+    return (
+        hass,
+        _write_price_list_log,
+        _log_price_change,
+        OptionsFlowHandler,
+        const_mod,
+        _cleanup,
+    )
 
 
 def test_group_drinks_same_minute(tmp_path):
-    hass, _write_price_list_log, cleanup = _setup_env(tmp_path)
+    hass, _write_price_list_log, _, _, _, cleanup = _setup_env(tmp_path)
     try:
         tz = ZoneInfo("Europe/Berlin")
         ts = datetime(2025, 9, 14, 1, 9, 30, tzinfo=tz)
@@ -118,7 +129,7 @@ def test_group_drinks_same_minute(tmp_path):
 
 
 def test_aggregate_same_drink(tmp_path):
-    hass, _write_price_list_log, cleanup = _setup_env(tmp_path)
+    hass, _write_price_list_log, _, _, _, cleanup = _setup_env(tmp_path)
     try:
         tz = ZoneInfo("Europe/Berlin")
         ts = datetime(2025, 9, 14, 1, 22, 15, tzinfo=tz)
@@ -144,7 +155,7 @@ def test_aggregate_same_drink(tmp_path):
 
 
 def test_free_drink_logged_separately(tmp_path):
-    hass, _write_price_list_log, cleanup = _setup_env(tmp_path)
+    hass, _write_price_list_log, _, _, _, cleanup = _setup_env(tmp_path)
     try:
         tz = ZoneInfo("Europe/Berlin")
         ts = datetime(2025, 9, 14, 1, 9, 30, tzinfo=tz)
@@ -177,5 +188,138 @@ def test_free_drink_logged_separately(tmp_path):
             "Robin Zimmermann:Bier+1",
         ]
         assert len(rows) == 3
+    finally:
+        cleanup()
+
+
+@pytest.mark.asyncio
+async def test_log_when_price_changed(tmp_path):
+    hass, _, _, OptionsFlowHandler, const, cleanup = _setup_env(tmp_path)
+    try:
+        hass.auth = types.SimpleNamespace(current_user=types.SimpleNamespace(id="user-1"))
+        flow = OptionsFlowHandler(config_entry=None)
+        flow.hass = hass
+        flow.context = {}
+        flow.async_step_menu = AsyncMock(return_value=None)
+        flow._user_id = "user-1"
+        flow._drinks = {"Bier": 1.6}
+        flow._drink_icons = {"Bier": "mdi:beer"}
+        flow._edit_drink = "Bier"
+        with patch("tally_list.config_flow._log_price_change", AsyncMock()) as log_mock:
+            await flow.async_step_edit_price({
+                const.CONF_PRICE: 1.7,
+                const.CONF_ICON: "mdi:beer",
+            })
+            log_mock.assert_awaited_once_with(
+                hass,
+                "user-1",
+                "edit_drink",
+                "Bier:1.6->1.7",
+            )
+    finally:
+        cleanup()
+
+
+@pytest.mark.asyncio
+async def test_no_log_when_price_unchanged(tmp_path):
+    hass, _, _, OptionsFlowHandler, const, cleanup = _setup_env(tmp_path)
+    try:
+        hass.auth = types.SimpleNamespace(current_user=types.SimpleNamespace(id="user-1"))
+        flow = OptionsFlowHandler(config_entry=None)
+        flow.hass = hass
+        flow.context = {}
+        flow.async_step_menu = AsyncMock(return_value=None)
+        flow._user_id = "user-1"
+        flow._drinks = {"Bier": 1.6}
+        flow._drink_icons = {"Bier": "mdi:beer"}
+        flow._edit_drink = "Bier"
+        with patch("tally_list.config_flow._log_price_change", AsyncMock()) as log_mock:
+            await flow.async_step_edit_price({
+                const.CONF_PRICE: 1.6,
+                const.CONF_ICON: "mdi:beer",
+            })
+            log_mock.assert_not_called()
+    finally:
+        cleanup()
+
+
+@pytest.mark.asyncio
+async def test_log_uses_context_user(tmp_path):
+    hass, _, _, OptionsFlowHandler, const, cleanup = _setup_env(tmp_path)
+    try:
+        flow = OptionsFlowHandler(config_entry=None)
+        flow.hass = hass
+        flow.context = {"user_id": "user-ctx"}
+        flow.async_step_menu = AsyncMock(return_value=None)
+        flow._user_id = None
+        flow._drinks = {"Bier": 1.6}
+        flow._drink_icons = {"Bier": "mdi:beer"}
+        flow._edit_drink = "Bier"
+        with patch("tally_list.config_flow._log_price_change", AsyncMock()) as log_mock:
+            await flow.async_step_edit_price({
+                const.CONF_PRICE: 1.7,
+                const.CONF_ICON: "mdi:beer",
+            })
+            log_mock.assert_awaited_once_with(
+                hass,
+                "user-ctx",
+                "edit_drink",
+                "Bier:1.6->1.7",
+            )
+    finally:
+        cleanup()
+
+
+@pytest.mark.asyncio
+async def test_log_price_change_uses_username(tmp_path):
+    hass, _write_price_list_log, _log_price_change, _, const, cleanup = _setup_env(tmp_path)
+    try:
+        hass.data = {const.DOMAIN: {}}
+        hass.states = types.SimpleNamespace(async_all=lambda domain: [])
+        mock_user = types.SimpleNamespace(name=None, username="tester")
+        hass.auth = types.SimpleNamespace(
+            async_get_user=AsyncMock(return_value=mock_user), current_user=None
+        )
+        hass.async_add_executor_job = AsyncMock()
+        await _log_price_change(
+            hass,
+            "user-id",
+            "edit_drink",
+            "Bier:1.6->1.7",
+        )
+        hass.async_add_executor_job.assert_awaited_once()
+        args = hass.async_add_executor_job.await_args.args
+        assert args[2] == "tester"
+    finally:
+        cleanup()
+
+
+@pytest.mark.asyncio
+async def test_user_id_preserved_after_init(tmp_path):
+    hass, _, _, OptionsFlowHandler, const, cleanup = _setup_env(tmp_path)
+    try:
+        hass.auth = types.SimpleNamespace(current_user=types.SimpleNamespace(id="user-1"))
+        hass.data = {const.DOMAIN: {}}
+        hass.config.language = "en"
+        flow = OptionsFlowHandler(config_entry=None)
+        flow.hass = hass
+        flow.context = {}
+        flow.async_step_menu = AsyncMock(return_value=None)
+        await flow.async_step_init()
+        hass.auth.current_user = None
+        flow._drinks = {"Bier": 1.6}
+        flow._drink_icons = {"Bier": "mdi:beer"}
+        flow._edit_drink = "Bier"
+        with patch("tally_list.config_flow._log_price_change", AsyncMock()) as log_mock:
+            await flow.async_step_edit_price({
+                const.CONF_PRICE: 1.7,
+                const.CONF_ICON: "mdi:beer",
+            })
+            log_mock.assert_awaited_once_with(
+                hass,
+                "user-1",
+                "edit_drink",
+                "Bier:1.6->1.7",
+            )
     finally:
         cleanup()


### PR DESCRIPTION
## Summary
- capture the user ID when an options flow starts and use it for subsequent price-change logs
- skip writing log entries when a drink price isn't modified
- add tests ensuring the stored user ID is used for logging and persists across flow steps

## Testing
- `pip install pytest-asyncio -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c694b00814832eb6f46d2c5104a5de