### PR TITLE
Add configurable logging to Tally List

### DIFF
--- a/custom_components/tally_list/__init__.py
+++ b/custom_components/tally_list/__init__.py
@@ -47,6 +47,10 @@ from .const import (
     CONF_ICONS,
     CONF_ENABLE_FREE_DRINKS,
     CONF_CASH_USER_NAME,
+    CONF_ENABLE_LOGGING,
+    CONF_LOG_DRINKS,
+    CONF_LOG_PRICE_CHANGES,
+    CONF_LOG_FREE_DRINKS,
     ATTR_FREE_DRINK,
     ATTR_COMMENT,
     ATTR_PIN,
@@ -94,6 +98,10 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             CONF_CURRENCY: "€",
             CONF_ENABLE_FREE_DRINKS: False,
             CONF_CASH_USER_NAME: get_cash_user_name(hass.config.language),
+            CONF_ENABLE_LOGGING: True,
+            CONF_LOG_DRINKS: True,
+            CONF_LOG_PRICE_CHANGES: True,
+            CONF_LOG_FREE_DRINKS: True,
             "free_drink_counts": {},
             "free_drinks_ledger": 0.0,
             "logins": {},
@@ -317,9 +325,12 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             hass.data[DOMAIN]["free_drinks_ledger"] = hass.data[DOMAIN].get(
                 "free_drinks_ledger", 0.0
             ) + price * count
-            await hass.async_add_executor_job(
-                _write_free_drink_log, user, drink, count, comment
-            )
+            if hass.data.get(DOMAIN, {}).get(CONF_ENABLE_LOGGING, True) and hass.data[DOMAIN].get(
+                CONF_LOG_FREE_DRINKS, True
+            ):
+                await hass.async_add_executor_job(
+                    _write_free_drink_log, user, drink, count, comment
+                )
             await _async_update_feed_sensor(hass)
             hass.bus.async_fire(
                 "tally_list_free_drink_created",
@@ -371,9 +382,12 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                 "free_drinks_ledger", 0.0
             ) - price * count
             comment = comment.strip()
-            await hass.async_add_executor_job(
-                _write_free_drink_log, user, drink, -count, comment
-            )
+            if hass.data.get(DOMAIN, {}).get(CONF_ENABLE_LOGGING, True) and hass.data[DOMAIN].get(
+                CONF_LOG_FREE_DRINKS, True
+            ):
+                await hass.async_add_executor_job(
+                    _write_free_drink_log, user, drink, -count, comment
+                )
             await _async_update_feed_sensor(hass)
             hass.bus.async_fire(
                 "tally_list_free_drink_reversed",
@@ -682,6 +696,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             CONF_EXCLUDED_USERS: [],
             CONF_OVERRIDE_USERS: [],
             CONF_CURRENCY: "€",
+            CONF_ENABLE_LOGGING: True,
+            CONF_LOG_DRINKS: True,
+            CONF_LOG_PRICE_CHANGES: True,
+            CONF_LOG_FREE_DRINKS: True,
         },
     )
     hass.data[DOMAIN].setdefault(entry.entry_id, {"entry": entry, "counts": {}, "credit": 0.0})
@@ -845,6 +863,30 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     elif hass.data[DOMAIN].get(CONF_PUBLIC_DEVICES) is not None:
         entry_data = dict(entry.data)
         entry_data[CONF_PUBLIC_DEVICES] = hass.data[DOMAIN][CONF_PUBLIC_DEVICES]
+        hass.config_entries.async_update_entry(entry, data=entry_data)
+    if entry.data.get(CONF_ENABLE_LOGGING) is not None:
+        hass.data[DOMAIN][CONF_ENABLE_LOGGING] = entry.data[CONF_ENABLE_LOGGING]
+    elif hass.data[DOMAIN].get(CONF_ENABLE_LOGGING) is not None:
+        entry_data = dict(entry.data)
+        entry_data[CONF_ENABLE_LOGGING] = hass.data[DOMAIN][CONF_ENABLE_LOGGING]
+        hass.config_entries.async_update_entry(entry, data=entry_data)
+    if entry.data.get(CONF_LOG_DRINKS) is not None:
+        hass.data[DOMAIN][CONF_LOG_DRINKS] = entry.data[CONF_LOG_DRINKS]
+    elif hass.data[DOMAIN].get(CONF_LOG_DRINKS) is not None:
+        entry_data = dict(entry.data)
+        entry_data[CONF_LOG_DRINKS] = hass.data[DOMAIN][CONF_LOG_DRINKS]
+        hass.config_entries.async_update_entry(entry, data=entry_data)
+    if entry.data.get(CONF_LOG_PRICE_CHANGES) is not None:
+        hass.data[DOMAIN][CONF_LOG_PRICE_CHANGES] = entry.data[CONF_LOG_PRICE_CHANGES]
+    elif hass.data[DOMAIN].get(CONF_LOG_PRICE_CHANGES) is not None:
+        entry_data = dict(entry.data)
+        entry_data[CONF_LOG_PRICE_CHANGES] = hass.data[DOMAIN][CONF_LOG_PRICE_CHANGES]
+        hass.config_entries.async_update_entry(entry, data=entry_data)
+    if entry.data.get(CONF_LOG_FREE_DRINKS) is not None:
+        hass.data[DOMAIN][CONF_LOG_FREE_DRINKS] = entry.data[CONF_LOG_FREE_DRINKS]
+    elif hass.data[DOMAIN].get(CONF_LOG_FREE_DRINKS) is not None:
+        entry_data = dict(entry.data)
+        entry_data[CONF_LOG_FREE_DRINKS] = hass.data[DOMAIN][CONF_LOG_FREE_DRINKS]
         hass.config_entries.async_update_entry(entry, data=entry_data)
     user_name = entry.data.get(CONF_USER)
     if user_name and entry.data.get(CONF_USER_PIN) is not None:

--- a/custom_components/tally_list/const.py
+++ b/custom_components/tally_list/const.py
@@ -16,6 +16,10 @@ CONF_CURRENCY = "currency"
 
 CONF_ENABLE_FREE_DRINKS = "enable_free_drinks"
 CONF_CASH_USER_NAME = "cash_user_name"
+CONF_ENABLE_LOGGING = "enable_logging"
+CONF_LOG_DRINKS = "log_drinks"
+CONF_LOG_PRICE_CHANGES = "log_price_changes"
+CONF_LOG_FREE_DRINKS = "log_free_drinks"
 
 ATTR_USER = "user"
 ATTR_DRINK = "drink"

--- a/custom_components/tally_list/translations/de.json
+++ b/custom_components/tally_list/translations/de.json
@@ -12,6 +12,7 @@
         "menu_options": {
           "user": "Nutzereinstellungen",
           "drinks": "Getränkeeinstellungen",
+          "logging": "Protokollierung",
           "finish": "Fertig"
         }
       },
@@ -37,6 +38,15 @@
           "edit": "Bearbeiten",
           "currency": "Währung setzen",
           "back": "Zurück"
+        }
+      },
+      "logging": {
+        "title": "Protokollierung",
+        "data": {
+          "enable_logging": "Logging aktivieren",
+          "log_drinks": "Getränke protokollieren",
+          "log_price_changes": "Preisänderungen protokollieren",
+          "log_free_drinks": "Freigetränke protokollieren"
         }
       },
       "add_drink": {
@@ -145,6 +155,7 @@
         "menu_options": {
           "user": "Nutzereinstellungen",
           "drinks": "Getränkeeinstellungen",
+          "logging": "Protokollierung",
           "cleanup": "Nicht mehr genutzte Sensoren entfernen",
           "delete": "Integration komplett entfernen",
           "finish": "Fertig"
@@ -173,6 +184,15 @@
           "currency": "Währung setzen",
           "free_drinks": "Freigetränke",
           "back": "Zurück"
+        }
+      },
+      "logging": {
+        "title": "Protokollierung",
+        "data": {
+          "enable_logging": "Logging aktivieren",
+          "log_drinks": "Getränke protokollieren",
+          "log_price_changes": "Preisänderungen protokollieren",
+          "log_free_drinks": "Freigetränke protokollieren"
         }
       },
       "free_drinks": {
@@ -302,6 +322,7 @@
       "action": {
         "user": "Nutzereinstellungen",
         "drinks": "Getränkeeinstellungen",
+        "logging": "Protokollierung",
         "free_drinks": "Freigetränke",
         "add": "Hinzufügen",
         "remove": "Entfernen",

--- a/custom_components/tally_list/translations/en.json
+++ b/custom_components/tally_list/translations/en.json
@@ -12,6 +12,7 @@
         "menu_options": {
           "user": "User settings",
           "drinks": "Drink settings",
+          "logging": "Logging settings",
           "finish": "Done"
         }
       },
@@ -37,6 +38,15 @@
           "edit": "Edit price",
           "currency": "Set currency",
           "back": "Back"
+        }
+      },
+      "logging": {
+        "title": "Logging settings",
+        "data": {
+          "enable_logging": "Enable logging",
+          "log_drinks": "Log drink events",
+          "log_price_changes": "Log price changes",
+          "log_free_drinks": "Log free drink events"
         }
       },
       "add_drink": {
@@ -145,6 +155,7 @@
         "menu_options": {
           "user": "User settings",
           "drinks": "Drink settings",
+          "logging": "Logging settings",
           "cleanup": "Remove unused sensors",
           "delete": "Delete all entries",
           "finish": "Done"
@@ -173,6 +184,15 @@
           "currency": "Set currency",
           "free_drinks": "Free drinks",
           "back": "Back"
+        }
+      },
+      "logging": {
+        "title": "Logging settings",
+        "data": {
+          "enable_logging": "Enable logging",
+          "log_drinks": "Log drink events",
+          "log_price_changes": "Log price changes",
+          "log_free_drinks": "Log free drink events"
         }
       },
       "free_drinks": {
@@ -302,6 +322,7 @@
       "action": {
         "user": "User settings",
         "drinks": "Drink settings",
+        "logging": "Logging settings",
         "free_drinks": "Free drinks",
         "add": "Add drink",
         "remove": "Remove drink",

--- a/tests/test_price_list_log.py
+++ b/tests/test_price_list_log.py
@@ -361,3 +361,59 @@ async def test_log_uses_request_user(tmp_path):
         current_request.reset(token)
     finally:
         cleanup()
+
+
+@pytest.mark.asyncio
+async def test_no_log_when_drinks_logging_disabled(tmp_path):
+    hass, _write_price_list_log, _log_price_change, _, const, cleanup = _setup_env(tmp_path)
+    try:
+        hass.data = {
+            const.DOMAIN: {
+                const.CONF_ENABLE_LOGGING: True,
+                const.CONF_LOG_DRINKS: False,
+            }
+        }
+        hass.states = types.SimpleNamespace(async_all=lambda domain: [])
+        hass.auth = types.SimpleNamespace(
+            async_get_user=AsyncMock(return_value=None), current_user=None
+        )
+        hass.async_add_executor_job = AsyncMock()
+        await _log_price_change(hass, "user-id", "add_drink", "Bier+1")
+        hass.async_add_executor_job.assert_not_called()
+    finally:
+        cleanup()
+
+
+@pytest.mark.asyncio
+async def test_logging_toggle_always_logged(tmp_path):
+    hass, _write_price_list_log, _, OptionsFlowHandler, const, cleanup = _setup_env(tmp_path)
+    try:
+        hass.data = {const.DOMAIN: {}}
+        hass.states = types.SimpleNamespace(async_all=lambda domain: [])
+        mock_user = types.SimpleNamespace(id="user-1", name="Tester", username="tester")
+        hass.auth = types.SimpleNamespace(
+            async_get_user=AsyncMock(return_value=mock_user), current_user=mock_user
+        )
+        flow = OptionsFlowHandler(config_entry=None)
+        flow.hass = hass
+        flow.context = {}
+        flow._enable_logging = False
+        flow._log_drinks = True
+        flow._log_price_changes = True
+        flow._log_free_drinks = True
+        flow.async_step_menu = AsyncMock(return_value=None)
+        hass.async_add_executor_job = AsyncMock()
+        await flow.async_step_logging(
+            {
+                const.CONF_ENABLE_LOGGING: True,
+                const.CONF_LOG_DRINKS: True,
+                const.CONF_LOG_PRICE_CHANGES: True,
+                const.CONF_LOG_FREE_DRINKS: True,
+            }
+        )
+        hass.async_add_executor_job.assert_awaited_once()
+        args = hass.async_add_executor_job.await_args.args
+        assert args[0] is _write_price_list_log
+        assert args[3] == "enable_logging"
+    finally:
+        cleanup()


### PR DESCRIPTION
## Summary
- allow enabling/disabling logging globally or per feature
- honor logging flags in services
- add missing logging translations in options flow
- log enable/disable events and allow toggling drink logs separately

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6a6fc68b0832e9fbcba8d2781b0b9