### PR TITLE
Log individual option toggles

### DIFF
--- a/custom_components/tally_list/config_flow.py
+++ b/custom_components/tally_list/config_flow.py
@@ -160,7 +160,7 @@ async def _log_price_change(hass, user_id, action: str, details: str) -> None:
     await _async_update_price_feed_sensor(hass)
 
 
-async def _log_logging_toggle(hass, user_id, enabled: bool) -> None:
+async def _log_logging_toggle(hass, user_id, option: str, enabled: bool) -> None:
     auth = getattr(hass, "auth", None)
     if user_id is None and auth is not None:
         current = getattr(auth, "current_user", None)
@@ -179,7 +179,7 @@ async def _log_logging_toggle(hass, user_id, enabled: bool) -> None:
         )
         or "Unknown"
     )
-    action = "enable_logging" if enabled else "disable_logging"
+    action = f"enable_{option}" if enabled else f"disable_{option}"
     await hass.async_add_executor_job(
         _write_price_list_log, hass, name, action, action
     )
@@ -445,11 +445,34 @@ class TallyListConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self._ensure_user_id()
             new_enable = user_input[CONF_ENABLE_LOGGING]
             if new_enable != self._enable_logging:
-                await _log_logging_toggle(self.hass, self._user_id, new_enable)
+                await _log_logging_toggle(
+                    self.hass, self._user_id, "logging", new_enable
+                )
             self._enable_logging = new_enable
-            self._log_drinks = user_input[CONF_LOG_DRINKS]
-            self._log_price_changes = user_input[CONF_LOG_PRICE_CHANGES]
-            self._log_free_drinks = user_input[CONF_LOG_FREE_DRINKS]
+
+            new_log_drinks = user_input[CONF_LOG_DRINKS]
+            if new_log_drinks != self._log_drinks:
+                await _log_logging_toggle(
+                    self.hass, self._user_id, "log_drinks", new_log_drinks
+                )
+            self._log_drinks = new_log_drinks
+
+            new_log_price_changes = user_input[CONF_LOG_PRICE_CHANGES]
+            if new_log_price_changes != self._log_price_changes:
+                await _log_logging_toggle(
+                    self.hass,
+                    self._user_id,
+                    "log_price_changes",
+                    new_log_price_changes,
+                )
+            self._log_price_changes = new_log_price_changes
+
+            new_log_free_drinks = user_input[CONF_LOG_FREE_DRINKS]
+            if new_log_free_drinks != self._log_free_drinks:
+                await _log_logging_toggle(
+                    self.hass, self._user_id, "log_free_drinks", new_log_free_drinks
+                )
+            self._log_free_drinks = new_log_free_drinks
             return await self.async_step_menu()
         schema = vol.Schema(
             {
@@ -1044,11 +1067,34 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
             self._ensure_user_id()
             new_enable = user_input[CONF_ENABLE_LOGGING]
             if new_enable != self._enable_logging:
-                await _log_logging_toggle(self.hass, self._user_id, new_enable)
+                await _log_logging_toggle(
+                    self.hass, self._user_id, "logging", new_enable
+                )
             self._enable_logging = new_enable
-            self._log_drinks = user_input[CONF_LOG_DRINKS]
-            self._log_price_changes = user_input[CONF_LOG_PRICE_CHANGES]
-            self._log_free_drinks = user_input[CONF_LOG_FREE_DRINKS]
+
+            new_log_drinks = user_input[CONF_LOG_DRINKS]
+            if new_log_drinks != self._log_drinks:
+                await _log_logging_toggle(
+                    self.hass, self._user_id, "log_drinks", new_log_drinks
+                )
+            self._log_drinks = new_log_drinks
+
+            new_log_price_changes = user_input[CONF_LOG_PRICE_CHANGES]
+            if new_log_price_changes != self._log_price_changes:
+                await _log_logging_toggle(
+                    self.hass,
+                    self._user_id,
+                    "log_price_changes",
+                    new_log_price_changes,
+                )
+            self._log_price_changes = new_log_price_changes
+
+            new_log_free_drinks = user_input[CONF_LOG_FREE_DRINKS]
+            if new_log_free_drinks != self._log_free_drinks:
+                await _log_logging_toggle(
+                    self.hass, self._user_id, "log_free_drinks", new_log_free_drinks
+                )
+            self._log_free_drinks = new_log_free_drinks
             return await self.async_step_menu()
         schema = vol.Schema(
             {

--- a/tests/test_price_list_log.py
+++ b/tests/test_price_list_log.py
@@ -417,3 +417,38 @@ async def test_logging_toggle_always_logged(tmp_path):
         assert args[3] == "enable_logging"
     finally:
         cleanup()
+
+
+@pytest.mark.asyncio
+async def test_individual_logging_toggle_logged(tmp_path):
+    hass, _write_price_list_log, _, OptionsFlowHandler, const, cleanup = _setup_env(tmp_path)
+    try:
+        hass.data = {const.DOMAIN: {}}
+        hass.states = types.SimpleNamespace(async_all=lambda domain: [])
+        mock_user = types.SimpleNamespace(id="user-1", name="Tester", username="tester")
+        hass.auth = types.SimpleNamespace(
+            async_get_user=AsyncMock(return_value=mock_user), current_user=mock_user
+        )
+        flow = OptionsFlowHandler(config_entry=None)
+        flow.hass = hass
+        flow.context = {}
+        flow._enable_logging = True
+        flow._log_drinks = False
+        flow._log_price_changes = True
+        flow._log_free_drinks = True
+        flow.async_step_menu = AsyncMock(return_value=None)
+        hass.async_add_executor_job = AsyncMock()
+        await flow.async_step_logging(
+            {
+                const.CONF_ENABLE_LOGGING: True,
+                const.CONF_LOG_DRINKS: True,
+                const.CONF_LOG_PRICE_CHANGES: True,
+                const.CONF_LOG_FREE_DRINKS: True,
+            }
+        )
+        hass.async_add_executor_job.assert_awaited_once()
+        args = hass.async_add_executor_job.await_args.args
+        assert args[0] is _write_price_list_log
+        assert args[3] == "enable_log_drinks"
+    finally:
+        cleanup()


### PR DESCRIPTION
## Summary
- log enable/disable events for specific logging options
- cover individual logging toggle with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6bd587564832e83efb3721f072d2a