### PR TITLE
Log individual option toggles

### DIFF
--- a/custom_components/tally_list/__init__.py
+++ b/custom_components/tally_list/__init__.py
@@ -51,6 +51,7 @@ from .const import (
     CONF_LOG_DRINKS,
     CONF_LOG_PRICE_CHANGES,
     CONF_LOG_FREE_DRINKS,
+    CONF_LOG_PIN_SET,
     ATTR_FREE_DRINK,
     ATTR_COMMENT,
     ATTR_PIN,
@@ -102,6 +103,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             CONF_LOG_DRINKS: True,
             CONF_LOG_PRICE_CHANGES: True,
             CONF_LOG_FREE_DRINKS: True,
+            CONF_LOG_PIN_SET: True,
             "free_drink_counts": {},
             "free_drinks_ledger": 0.0,
             "logins": {},
@@ -700,6 +702,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             CONF_LOG_DRINKS: True,
             CONF_LOG_PRICE_CHANGES: True,
             CONF_LOG_FREE_DRINKS: True,
+            CONF_LOG_PIN_SET: True,
         },
     )
     hass.data[DOMAIN].setdefault(entry.entry_id, {"entry": entry, "counts": {}, "credit": 0.0})
@@ -887,6 +890,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     elif hass.data[DOMAIN].get(CONF_LOG_FREE_DRINKS) is not None:
         entry_data = dict(entry.data)
         entry_data[CONF_LOG_FREE_DRINKS] = hass.data[DOMAIN][CONF_LOG_FREE_DRINKS]
+        hass.config_entries.async_update_entry(entry, data=entry_data)
+    if entry.data.get(CONF_LOG_PIN_SET) is not None:
+        hass.data[DOMAIN][CONF_LOG_PIN_SET] = entry.data[CONF_LOG_PIN_SET]
+    elif hass.data[DOMAIN].get(CONF_LOG_PIN_SET) is not None:
+        entry_data = dict(entry.data)
+        entry_data[CONF_LOG_PIN_SET] = hass.data[DOMAIN][CONF_LOG_PIN_SET]
         hass.config_entries.async_update_entry(entry, data=entry_data)
     user_name = entry.data.get(CONF_USER)
     if user_name and entry.data.get(CONF_USER_PIN) is not None:

--- a/custom_components/tally_list/const.py
+++ b/custom_components/tally_list/const.py
@@ -20,6 +20,7 @@ CONF_ENABLE_LOGGING = "enable_logging"
 CONF_LOG_DRINKS = "log_drinks"
 CONF_LOG_PRICE_CHANGES = "log_price_changes"
 CONF_LOG_FREE_DRINKS = "log_free_drinks"
+CONF_LOG_PIN_SET = "log_pin_set"
 
 ATTR_USER = "user"
 ATTR_DRINK = "drink"


### PR DESCRIPTION
## Summary
- add `log_pin_set` option to control logging of PIN changes
- unify logging toggle records to use enable/disable actions with option details
- expand tests for pin logging and consolidated toggle logging

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6bd587564832e83efb3721f072d2a