### PR TITLE
Add missing translation for PIN logging

### DIFF
--- a/custom_components/tally_list/translations/de.json
+++ b/custom_components/tally_list/translations/de.json
@@ -46,7 +46,8 @@
           "enable_logging": "Logging aktivieren",
           "log_drinks": "Getränke protokollieren",
           "log_price_changes": "Preisänderungen protokollieren",
-          "log_free_drinks": "Freigetränke protokollieren"
+          "log_free_drinks": "Freigetränke protokollieren",
+          "log_pin_set": "PIN-Änderungen protokollieren"
         }
       },
       "add_drink": {

--- a/custom_components/tally_list/translations/en.json
+++ b/custom_components/tally_list/translations/en.json
@@ -46,7 +46,8 @@
           "enable_logging": "Enable logging",
           "log_drinks": "Log drink events",
           "log_price_changes": "Log price changes",
-          "log_free_drinks": "Log free drink events"
+          "log_free_drinks": "Log free drink events",
+          "log_pin_set": "Log PIN set events"
         }
       },
       "add_drink": {


### PR DESCRIPTION
## Summary
- localize PIN logging option in English and German translations

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c6c29a2bf0832e9a7f7cc1e25e186a