### PR TITLE
Add missing log_pin_set option translations

### DIFF
--- a/custom_components/tally_list/translations/de.json
+++ b/custom_components/tally_list/translations/de.json
@@ -193,7 +193,8 @@
           "enable_logging": "Logging aktivieren",
           "log_drinks": "Getränke protokollieren",
           "log_price_changes": "Preisänderungen protokollieren",
-          "log_free_drinks": "Freigetränke protokollieren"
+          "log_free_drinks": "Freigetränke protokollieren",
+          "log_pin_set": "PIN-Änderungen protokollieren"
         }
       },
       "free_drinks": {

--- a/custom_components/tally_list/translations/en.json
+++ b/custom_components/tally_list/translations/en.json
@@ -193,7 +193,8 @@
           "enable_logging": "Enable logging",
           "log_drinks": "Log drink events",
           "log_price_changes": "Log price changes",
-          "log_free_drinks": "Log free drink events"
+          "log_free_drinks": "Log free drink events",
+          "log_pin_set": "Log PIN set events"
         }
       },
       "free_drinks": {


### PR DESCRIPTION
## Summary
- Add `log_pin_set` entry to OptionsFlow logging settings for English and German translations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6c5e97824832eba9046b1f877cda4