### PR TITLE
Add configurable logging for free drinks and user management

### DIFF
--- a/custom_components/tally_list/const.py
+++ b/custom_components/tally_list/const.py
@@ -21,6 +21,7 @@ CONF_LOG_DRINKS = "log_drinks"
 CONF_LOG_PRICE_CHANGES = "log_price_changes"
 CONF_LOG_FREE_DRINKS = "log_free_drinks"
 CONF_LOG_PIN_SET = "log_pin_set"
+CONF_LOG_SETTINGS = "log_settings"
 
 ATTR_USER = "user"
 ATTR_DRINK = "drink"

--- a/custom_components/tally_list/translations/de.json
+++ b/custom_components/tally_list/translations/de.json
@@ -47,7 +47,8 @@
           "log_drinks": "Getränke protokollieren",
           "log_price_changes": "Preisänderungen protokollieren",
           "log_free_drinks": "Freigetränke protokollieren",
-          "log_pin_set": "PIN-Änderungen protokollieren"
+          "log_pin_set": "PIN-Änderungen protokollieren",
+          "log_settings": "Einstellungen protokollieren"
         }
       },
       "add_drink": {
@@ -194,7 +195,8 @@
           "log_drinks": "Getränke protokollieren",
           "log_price_changes": "Preisänderungen protokollieren",
           "log_free_drinks": "Freigetränke protokollieren",
-          "log_pin_set": "PIN-Änderungen protokollieren"
+          "log_pin_set": "PIN-Änderungen protokollieren",
+          "log_settings": "Einstellungen protokollieren"
         }
       },
       "free_drinks": {

--- a/custom_components/tally_list/translations/en.json
+++ b/custom_components/tally_list/translations/en.json
@@ -47,7 +47,8 @@
           "log_drinks": "Log drink events",
           "log_price_changes": "Log price changes",
           "log_free_drinks": "Log free drink events",
-          "log_pin_set": "Log PIN set events"
+          "log_pin_set": "Log PIN set events",
+          "log_settings": "Log settings changes"
         }
       },
       "add_drink": {
@@ -194,7 +195,8 @@
           "log_drinks": "Log drink events",
           "log_price_changes": "Log price changes",
           "log_free_drinks": "Log free drink events",
-          "log_pin_set": "Log PIN set events"
+          "log_pin_set": "Log PIN set events",
+          "log_settings": "Log settings changes"
         }
       },
       "free_drinks": {


### PR DESCRIPTION
## Summary
- log enabling/disabling of free drinks when price change logging is active
- add `log_settings` option to record user exclusions, admin grants and public device authorizations
- cover new logging with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6cbf88170832eb876f9ed58801bdb