### PR TITLE
Bump version to 16.09.25 and fix options flow deprecation

### DIFF
--- a/custom_components/tally_list/config_flow.py
+++ b/custom_components/tally_list/config_flow.py
@@ -1047,7 +1047,6 @@ class TallyListOptionsFlowHandler(config_entries.OptionsFlow):
     """Handle options."""
 
     def __init__(self, config_entry):
-        self.config_entry = config_entry
         self._user_id: str | None = None
         self._drinks: dict[str, float] = {}
         self._drink_icons: dict[str, str] = {}

--- a/custom_components/tally_list/manifest.json
+++ b/custom_components/tally_list/manifest.json
@@ -3,7 +3,7 @@
   "name": "Tally List",
   "documentation": "https://github.com/Spider19996/ha-tally-list",
   "issue_tracker": "https://github.com/Spider19996/ha-tally-list/issues",
-  "version": "14.09.25",
+  "version": "16.09.25",
   "requirements": [],
   "config_flow": true,
   "codeowners": ["@Spider19996"],


### PR DESCRIPTION
## Summary
- bump the integration manifest version to 16.09.25
- stop assigning the options flow config entry attribute to avoid the Home Assistant deprecation warning

## Testing
- pytest *(fails: async tests require pytest-asyncio in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9c6296da4832ea061c502c3f0c3ef